### PR TITLE
feat: Implement blog/insights pages with editorial layout

### DIFF
--- a/sanity/schemas/blogPost.ts
+++ b/sanity/schemas/blogPost.ts
@@ -12,6 +12,27 @@ export const blogPost = defineType({
     defineField({ name: 'publishedAt', type: 'datetime', title: 'Published At' }),
     defineField({ name: 'featuredImage', type: 'image', title: 'Featured Image', options: { hotspot: true } }),
     defineField({ name: 'excerpt', type: 'text', title: 'Excerpt', rows: 3 }),
+    defineField({
+      name: 'readTime',
+      type: 'string',
+      title: 'Read Time',
+      description: 'e.g., "5 min" or "10 min"',
+      placeholder: '5 min'
+    }),
+    defineField({
+      name: 'featured',
+      type: 'boolean',
+      title: 'Featured',
+      description: 'Mark as featured post for homepage',
+      initialValue: false
+    }),
+    defineField({
+      name: 'tags',
+      type: 'array',
+      title: 'Tags',
+      of: [{ type: 'string' }],
+      options: { layout: 'tags' }
+    }),
     defineField({ name: 'content', type: 'array', title: 'Content', of: [
       { type: 'richText' },
       { type: 'image', options: { hotspot: true } },

--- a/src/components/cards/BlogCard.astro
+++ b/src/components/cards/BlogCard.astro
@@ -1,0 +1,208 @@
+---
+import { urlFor } from '../../lib/sanity';
+import { formatDate } from '../../lib/utils';
+
+interface Props {
+  post: {
+    _id: string;
+    title: string;
+    slug: { current: string };
+    excerpt?: string;
+    featuredImage?: any;
+    publishedAt?: string;
+    readTime?: string;
+    category?: { title: string; slug: { current: string } };
+  };
+}
+
+const { post } = Astro.props;
+
+let imageUrl: string | undefined;
+if (post.featuredImage) {
+  try {
+    imageUrl = urlFor(post.featuredImage).width(800).height(500).format('webp').url();
+  } catch {
+    // No image
+  }
+}
+
+const formattedDate = post.publishedAt ? formatDate(post.publishedAt) : undefined;
+---
+
+<a
+  href={`/insights/${post.slug.current}/`}
+  class="blog-card"
+  style={post.slug?.current ? `view-transition-name: blog-card-${post.slug.current}` : undefined}
+>
+  <div class="blog-card__image">
+    {imageUrl ? (
+      <img
+        src={imageUrl}
+        alt={post.title}
+        width="800"
+        height="500"
+        loading="lazy"
+        decoding="async"
+        style={post.slug?.current ? `view-transition-name: blog-hero-${post.slug.current}` : undefined}
+      />
+    ) : (
+      <div class="blog-card__placeholder" />
+    )}
+    <div class="blog-card__overlay" />
+  </div>
+  <div class="blog-card__content">
+    {post.category && (
+      <span class="blog-card__category">{post.category.title}</span>
+    )}
+    <h3
+      class="blog-card__title"
+      style={post.slug?.current ? `view-transition-name: blog-title-${post.slug.current}` : undefined}
+    >
+      {post.title}
+    </h3>
+    {post.excerpt && (
+      <p class="blog-card__excerpt">{post.excerpt}</p>
+    )}
+    <div class="blog-card__footer">
+      {formattedDate && (
+        <span class="blog-card__date">{formattedDate}</span>
+      )}
+      {post.readTime && (
+        <span class="blog-card__read-time">{post.readTime}</span>
+      )}
+    </div>
+  </div>
+</a>
+
+<style>
+  .blog-card {
+    display: block;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-left: 3px solid transparent;
+    text-decoration: none;
+    overflow: hidden;
+    transition: border-color 0.3s ease, transform 0.3s ease;
+  }
+
+  .blog-card:hover {
+    border-left-color: var(--accent);
+    transform: translateY(-2px);
+  }
+
+  /* ---- Card image ---- */
+  .blog-card__image {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+  }
+
+  .blog-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+
+  .blog-card:hover .blog-card__image img {
+    transform: scale(1.05);
+  }
+
+  .blog-card__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(10, 10, 10, 0.6) 0%, transparent 50%);
+    pointer-events: none;
+  }
+
+  .blog-card__placeholder {
+    width: 100%;
+    height: 100%;
+    background: var(--bg-tertiary);
+  }
+
+  /* ---- Card content ---- */
+  .blog-card__content {
+    padding: 1.25rem 1.5rem 1.5rem;
+  }
+
+  .blog-card__category {
+    display: inline-block;
+    font-family: var(--font-body);
+    font-size: 10px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.1);
+    padding: 4px 10px;
+    margin-bottom: 0.75rem;
+  }
+
+  .blog-card__title {
+    font-family: var(--font-display);
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 1.3;
+    color: var(--text-primary);
+    margin: 0 0 0.75rem;
+    transition: color 0.3s ease;
+  }
+
+  .blog-card:hover .blog-card__title {
+    color: var(--accent);
+  }
+
+  .blog-card__excerpt {
+    font-family: var(--font-body);
+    font-size: 0.9375rem;
+    font-weight: 300;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0 0 1rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .blog-card__footer {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .blog-card__date {
+    font-family: var(--font-body);
+    font-size: 0.75rem;
+    font-weight: 300;
+    color: var(--text-muted);
+  }
+
+  .blog-card__read-time {
+    font-family: var(--font-body);
+    font-size: 0.75rem;
+    font-weight: 300;
+    color: var(--text-muted);
+  }
+
+  .blog-card__read-time::before {
+    content: '•';
+    margin-right: 1rem;
+    color: var(--border-light);
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 768px) {
+    .blog-card__title {
+      font-size: 1rem;
+    }
+
+    .blog-card__excerpt {
+      font-size: 0.875rem;
+    }
+  }
+</style>

--- a/src/components/sections/AuthorBio.astro
+++ b/src/components/sections/AuthorBio.astro
@@ -1,6 +1,6 @@
 ---
 import { urlFor } from '../../lib/sanity';
-import { Linkedin, Twitter } from 'lucide-astro';
+import { Linkedin, Twitter } from '@lucide/astro';
 
 interface Props {
   author: {

--- a/src/components/sections/AuthorBio.astro
+++ b/src/components/sections/AuthorBio.astro
@@ -1,0 +1,223 @@
+---
+import { urlFor } from '../../lib/sanity';
+import { Linkedin, Twitter } from 'lucide-astro';
+
+interface Props {
+  author: {
+    name: string;
+    role?: string;
+    bio?: string;
+    photo?: any;
+    linkedin?: string;
+    twitter?: string;
+  };
+}
+
+const { author } = Astro.props;
+
+let photoUrl: string | undefined;
+if (author.photo) {
+  try {
+    photoUrl = urlFor(author.photo).width(96).height(96).format('webp').url();
+  } catch {
+    // No photo
+  }
+}
+---
+
+<section class="author-bio">
+  <div class="author-bio__container">
+    <div class="author-bio__content">
+      <div class="author-bio__profile">
+        {photoUrl ? (
+          <img
+            src={photoUrl}
+            alt={author.name}
+            class="author-bio__photo"
+            width="48"
+            height="48"
+            loading="lazy"
+            decoding="async"
+          />
+        ) : (
+          <div class="author-bio__photo-placeholder">
+            {author.name.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div class="author-bio__info">
+          <h3 class="author-bio__name">{author.name}</h3>
+          {author.role && (
+            <p class="author-bio__role">{author.role}</p>
+          )}
+          {author.bio && (
+            <p class="author-bio__bio">{author.bio}</p>
+          )}
+        </div>
+      </div>
+      {(author.linkedin || author.twitter) && (
+        <div class="author-bio__social">
+          {author.linkedin && (
+            <a
+              href={author.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="author-bio__social-link"
+              aria-label="LinkedIn"
+            >
+              <Linkedin size={18} />
+            </a>
+          )}
+          {author.twitter && (
+            <a
+              href={author.twitter}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="author-bio__social-link"
+              aria-label="Twitter"
+            >
+              <Twitter size={18} />
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  </div>
+</section>
+
+<style>
+  .author-bio {
+    padding: 4rem 0;
+    background: var(--bg-secondary);
+  }
+
+  .author-bio__container {
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  .author-bio__content {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+    padding: 2rem 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .author-bio__profile {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    flex: 1;
+  }
+
+  .author-bio__photo {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .author-bio__photo-placeholder {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--bg-tertiary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    font-weight: 500;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+
+  .author-bio__info {
+    flex: 1;
+  }
+
+  .author-bio__name {
+    font-family: var(--font-body);
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    margin: 0 0 0.25rem;
+  }
+
+  .author-bio__role {
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 300;
+    color: var(--text-muted);
+    margin: 0 0 0.5rem;
+  }
+
+  .author-bio__bio {
+    font-family: var(--font-body);
+    font-size: 0.9375rem;
+    font-weight: 300;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  .author-bio__social {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .author-bio__social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    transition: all 0.3s ease;
+  }
+
+  .author-bio__social-link:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.05);
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 768px) {
+    .author-bio {
+      padding: 3rem 0;
+    }
+
+    .author-bio__content {
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .author-bio__social {
+      justify-content: flex-start;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .author-bio__container {
+      padding: 0 1rem;
+    }
+
+    .author-bio__content {
+      padding: 1.5rem 0;
+    }
+
+    .author-bio__bio {
+      font-size: 0.875rem;
+    }
+  }
+</style>

--- a/src/components/sections/BlogPostContent.astro
+++ b/src/components/sections/BlogPostContent.astro
@@ -1,0 +1,252 @@
+---
+import { PortableText } from 'astro-portabletext';
+import PortableTextImage from '../ui/PortableTextImage.astro';
+import PortableTextHighlight from '../ui/PortableTextHighlight.astro';
+import PortableTextCode from '../ui/PortableTextCode.astro';
+
+interface Props {
+  content?: any[];
+}
+
+const { content = [] } = Astro.props;
+
+const components = {
+  type: {
+    image: PortableTextImage,
+    code: PortableTextCode,
+  },
+  mark: {
+    highlight: PortableTextHighlight,
+  },
+};
+
+const hasContent = content && content.length > 0;
+---
+
+{hasContent && (
+  <section class="blog-content">
+    <div class="blog-content__container">
+      <article class="blog-content__body">
+        <PortableText value={content} components={components} />
+      </article>
+    </div>
+  </section>
+)}
+
+<style>
+  .blog-content {
+    padding: 6rem 0;
+    background: var(--bg-primary);
+    overflow-x: hidden;
+  }
+
+  .blog-content__container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  .blog-content__body {
+    max-width: 820px;
+    margin: 0 auto;
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    font-weight: 300;
+    line-height: 1.8;
+    color: var(--text-secondary);
+  }
+
+  /* ---- Paragraphs ---- */
+  .blog-content__body :global(p) {
+    margin-bottom: 1.5rem;
+  }
+
+  .blog-content__body :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  /* ---- Bold / links ---- */
+  .blog-content__body :global(strong) {
+    font-weight: 500;
+    color: var(--text-primary);
+  }
+
+  .blog-content__body :global(a) {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    transition: color 0.2s;
+  }
+
+  .blog-content__body :global(a:hover) {
+    color: var(--accent-light);
+  }
+
+  /* ---- Lists ---- */
+  .blog-content__body :global(ul) {
+    margin: 1.5rem 0;
+    padding-left: 1.5rem;
+    list-style: none;
+  }
+
+  .blog-content__body :global(ol) {
+    margin: 1.5rem 0;
+    padding-left: 1.5rem;
+    list-style: decimal;
+    color: var(--accent);
+  }
+
+  .blog-content__body :global(ol > li) {
+    padding-left: 0.5rem;
+    color: var(--text-secondary);
+  }
+
+  .blog-content__body :global(li) {
+    margin-bottom: 0.5rem;
+  }
+
+  .blog-content__body :global(ul > li) {
+    position: relative;
+    padding-left: 1.25rem;
+  }
+
+  .blog-content__body :global(ul > li::before) {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.7em;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+  }
+
+  /* ---- Headings ---- */
+  .blog-content__body :global(h2),
+  .blog-content__body :global(h3) {
+    font-family: var(--font-display);
+    font-weight: 500;
+    color: var(--text-primary);
+    margin: 2.5rem 0 1rem;
+    line-height: 1.2;
+  }
+
+  .blog-content__body :global(h2) {
+    font-size: 1.875rem;
+  }
+
+  .blog-content__body :global(h3) {
+    font-size: 1.5rem;
+  }
+
+  /* ---- Blockquote: gold border strip ---- */
+  .blog-content__body :global(blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 2rem;
+    margin: 2.5rem 0;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 1.25rem;
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--text-primary);
+  }
+
+  .blog-content__body :global(blockquote p) {
+    margin-bottom: 0;
+  }
+
+  /* ---- Images: breakout effect with negative margins ---- */
+  .blog-content__body :global(.portable-text-image) {
+    margin: 3rem -4rem;
+    position: relative;
+  }
+
+  .blog-content__body :global(.portable-text-image img) {
+    width: 100%;
+    height: auto;
+    border: 1px solid var(--border-light);
+  }
+
+  .blog-content__body :global(.portable-text-image figcaption) {
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+    margin-top: 0.75rem;
+    padding: 0 4rem;
+    font-style: italic;
+  }
+
+  /* ---- Code blocks ---- */
+  .blog-content__body :global(.portable-text-code) {
+    margin: 2.5rem -2rem;
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 1024px) {
+    .blog-content__body :global(.portable-text-image) {
+      margin: 2.5rem -2rem;
+    }
+
+    .blog-content__body :global(.portable-text-image figcaption) {
+      padding: 0 2rem;
+    }
+
+    .blog-content__body :global(.portable-text-code) {
+      margin: 2rem -1rem;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .blog-content {
+      padding: 4rem 0;
+    }
+
+    .blog-content__body {
+      font-size: 1rem;
+    }
+
+    .blog-content__body :global(h2) {
+      font-size: 1.625rem;
+    }
+
+    .blog-content__body :global(h3) {
+      font-size: 1.25rem;
+    }
+
+    .blog-content__body :global(blockquote) {
+      padding-left: 1.5rem;
+      font-size: 1.125rem;
+    }
+
+    .blog-content__body :global(.portable-text-image) {
+      margin: 2rem -1.5rem;
+    }
+
+    .blog-content__body :global(.portable-text-image figcaption) {
+      padding: 0 1.5rem;
+    }
+
+    .blog-content__body :global(.portable-text-code) {
+      margin: 1.5rem 0;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .blog-content {
+      padding: 3rem 0;
+    }
+
+    .blog-content__container {
+      padding: 0 1rem;
+    }
+
+    .blog-content__body :global(.portable-text-image) {
+      margin: 1.5rem -1rem;
+    }
+
+    .blog-content__body :global(.portable-text-image figcaption) {
+      padding: 0 1rem;
+    }
+  }
+</style>

--- a/src/components/sections/BlogPostHero.astro
+++ b/src/components/sections/BlogPostHero.astro
@@ -1,0 +1,153 @@
+---
+import PageHero from './PageHero.astro';
+import SectionLabel from '../ui/SectionLabel.astro';
+import { formatDate } from '../../lib/utils';
+
+interface Props {
+  post: {
+    title: string;
+    slug?: { current: string };
+    category?: { title: string; slug: { current: string } };
+    publishedAt?: string;
+    readTime?: string;
+    author?: { name: string; slug?: { current: string } };
+    heroImageUrl?: string;
+  };
+}
+
+const { post } = Astro.props;
+const formattedDate = post.publishedAt ? formatDate(post.publishedAt) : undefined;
+const slug = post.slug?.current;
+---
+
+<PageHero
+  image={post.heroImageUrl}
+  variant="inner"
+  imageTransitionName={slug ? `blog-hero-${slug}` : undefined}
+>
+  <nav class="blog-hero__breadcrumb" aria-label="Breadcrumb">
+    <a href="/">Home</a>
+    <span class="blog-hero__sep">/</span>
+    <a href="/insights/">Insights</a>
+    {post.category && (
+      <>
+        <span class="blog-hero__sep">/</span>
+        <a href={`/insights/category/${post.category.slug.current}/`}>{post.category.title}</a>
+      </>
+    )}
+    <span class="blog-hero__sep">/</span>
+    <span class="blog-hero__current">{post.title}</span>
+  </nav>
+
+  <SectionLabel text="Insights" />
+
+  <h1 style={slug ? `view-transition-name: blog-title-${slug}` : undefined}>
+    {post.title}
+  </h1>
+
+  <div class="blog-hero__meta">
+    {post.category && (
+      <span class="blog-hero__category">{post.category.title}</span>
+    )}
+    {formattedDate && (
+      <span class="blog-hero__meta-item">{formattedDate}</span>
+    )}
+    {post.readTime && (
+      <span class="blog-hero__meta-item">{post.readTime} read</span>
+    )}
+    {post.author && (
+      <span class="blog-hero__meta-item">
+        By {post.author.name}
+      </span>
+    )}
+  </div>
+</PageHero>
+
+<style>
+  .blog-hero__breadcrumb {
+    font-family: var(--font-body);
+    font-size: 11px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+  }
+
+  .blog-hero__breadcrumb a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .blog-hero__breadcrumb a:hover {
+    color: var(--accent);
+  }
+
+  .blog-hero__sep {
+    margin: 0 8px;
+    color: var(--text-muted);
+  }
+
+  .blog-hero__current {
+    color: var(--accent);
+    display: inline-block;
+    max-width: 300px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+  }
+
+  .blog-hero__meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 300;
+    color: var(--text-secondary);
+  }
+
+  .blog-hero__category {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.1);
+    padding: 6px 12px;
+  }
+
+  .blog-hero__meta-item {
+    position: relative;
+  }
+
+  .blog-hero__meta-item:not(:first-child)::before {
+    content: '•';
+    position: absolute;
+    left: -0.6rem;
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 768px) {
+    .blog-hero__breadcrumb {
+      font-size: 10px;
+    }
+
+    .blog-hero__current {
+      max-width: 200px;
+    }
+
+    .blog-hero__meta {
+      font-size: 0.8125rem;
+      gap: 0.75rem;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .blog-hero__breadcrumb {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/sections/RelatedPosts.astro
+++ b/src/components/sections/RelatedPosts.astro
@@ -1,0 +1,104 @@
+---
+import SectionLabel from '../ui/SectionLabel.astro';
+import BlogCard from '../cards/BlogCard.astro';
+
+interface Props {
+  posts: Array<{
+    _id: string;
+    title: string;
+    slug: { current: string };
+    excerpt?: string;
+    featuredImage?: any;
+    publishedAt?: string;
+    readTime?: string;
+    category?: { title: string; slug: { current: string } };
+  }>;
+}
+
+const { posts } = Astro.props;
+---
+
+{posts && posts.length > 0 && (
+  <section class="related-posts">
+    <div class="related-posts__container">
+      <div class="related-posts__header">
+        <SectionLabel text="Related" />
+        <h2>Related Articles</h2>
+      </div>
+      <div class="related-posts__grid">
+        {posts.slice(0, 3).map((post) => (
+          <BlogCard post={post} />
+        ))}
+      </div>
+    </div>
+  </section>
+)}
+
+<style>
+  .related-posts {
+    padding: 6rem 0;
+    background: var(--bg-primary);
+    border-top: 1px solid var(--border);
+  }
+
+  .related-posts__container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  .related-posts__header {
+    margin-bottom: 4rem;
+  }
+
+  .related-posts__header h2 {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 500;
+    line-height: 1.1;
+    color: var(--text-primary);
+    margin: 1rem 0 0;
+  }
+
+  .related-posts__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 1024px) {
+    .related-posts__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .related-posts {
+      padding: 4rem 0;
+    }
+
+    .related-posts__header {
+      margin-bottom: 3rem;
+    }
+
+    .related-posts__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .related-posts {
+      padding: 3rem 0;
+    }
+
+    .related-posts__container {
+      padding: 0 1rem;
+    }
+
+    .related-posts__header {
+      margin-bottom: 2rem;
+    }
+  }
+</style>

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -332,10 +332,13 @@ export const blogPostBySlugQuery = `
       name,
       role,
       photo,
-      bio
+      bio,
+      linkedin,
+      twitter
     },
     tags,
-    seo,
+    seoTitle,
+    seoDescription,
     "relatedPosts": *[_type == "blogPost" && slug.current != $slug && (
       category._ref == ^.category._ref ||
       count(tags[@in ^.^.tags]) > 0

--- a/src/pages/insights/[...page].astro
+++ b/src/pages/insights/[...page].astro
@@ -8,13 +8,20 @@ import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { allBlogPostsQuery, allBlogCategoriesQuery } from '../../lib/queries';
 import { formatDate } from '../../lib/utils';
+import type { GetStaticPathsOptions } from 'astro';
 
-const posts = await client.fetch(allBlogPostsQuery);
+export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
+  const posts = await client.fetch(allBlogPostsQuery);
+  // 7 per page: page 1 = 1 featured + 6 grid; page 2+ = 7 grid
+  return paginate(posts, { pageSize: 7 });
+}
+
+const { page } = Astro.props;
 const categories = await client.fetch(allBlogCategoriesQuery);
 
-// Auto-select first post as featured
-const featuredPost = posts[0];
-const gridPosts = posts.slice(1, 7); // Show 6 more posts (1 featured + 6 grid = 7 total)
+const isFirstPage = page.currentPage === 1;
+const featuredPost = isFirstPage ? page.data[0] : undefined;
+const gridPosts = isFirstPage ? page.data.slice(1) : page.data;
 
 let featuredImageUrl: string | undefined;
 if (featuredPost?.featuredImage) {
@@ -25,10 +32,16 @@ if (featuredPost?.featuredImage) {
   }
 }
 
-const formattedFeaturedDate = featuredPost?.publishedAt ? formatDate(featuredPost.publishedAt) : undefined;
+const formattedFeaturedDate = featuredPost?.publishedAt
+  ? formatDate(featuredPost.publishedAt)
+  : undefined;
 
-const seoTitle = 'Insights & Articles';
-const seoDescription = 'Expert insights on design, development, and digital transformation. Learn from our experience building digital products that drive business growth.';
+const seoTitle =
+  page.currentPage === 1
+    ? 'Insights & Articles'
+    : `Insights & Articles — Page ${page.currentPage}`;
+const seoDescription =
+  'Expert insights on design, development, and digital transformation. Learn from our experience building digital products that drive business growth.';
 ---
 
 <BaseLayout title={seoTitle} description={seoDescription}>
@@ -45,26 +58,29 @@ const seoDescription = 'Expert insights on design, development, and digital tran
 
   <section class="insights-list">
     <div class="insights-list__container">
-      <!-- Category filter pills -->
+
+      <!-- Category filter pills — nav links to category pages -->
       {categories && categories.length > 0 && (
-        <div class="insights-list__filters" role="tablist" aria-label="Filter articles by category">
-          <button class="insights-list__pill insights-list__pill--active" data-filter="all" role="tab" aria-selected="true">
+        <nav class="insights-list__filters" aria-label="Filter articles by category">
+          <a href="/insights/" class="insights-list__pill insights-list__pill--active" aria-current="page">
             All
-          </button>
+          </a>
           {categories.map((cat) => (
-            <button class="insights-list__pill" data-filter={cat._id} role="tab" aria-selected="false">
+            <a
+              href={`/insights/category/${cat.slug.current}/`}
+              class="insights-list__pill"
+            >
               {cat.title}
-            </button>
+            </a>
           ))}
-        </div>
+        </nav>
       )}
 
-      <!-- Featured post (large) -->
+      <!-- Featured post — only on page 1 -->
       {featuredPost && (
         <a
           href={`/insights/${featuredPost.slug.current}/`}
           class="featured-post"
-          data-categories={featuredPost.category?._id || ''}
           style={featuredPost.slug?.current ? `view-transition-name: blog-card-${featuredPost.slug.current}` : undefined}
         >
           <div class="featured-post__image">
@@ -96,12 +112,8 @@ const seoDescription = 'Expert insights on design, development, and digital tran
               <p class="featured-post__excerpt">{featuredPost.excerpt}</p>
             )}
             <div class="featured-post__meta">
-              {formattedFeaturedDate && (
-                <span>{formattedFeaturedDate}</span>
-              )}
-              {featuredPost.readTime && (
-                <span>{featuredPost.readTime} read</span>
-              )}
+              {formattedFeaturedDate && <span>{formattedFeaturedDate}</span>}
+              {featuredPost.readTime && <span>{featuredPost.readTime} read</span>}
             </div>
           </div>
         </a>
@@ -111,19 +123,53 @@ const seoDescription = 'Expert insights on design, development, and digital tran
       {gridPosts && gridPosts.length > 0 && (
         <div class="insights-list__grid">
           {gridPosts.map((post) => (
-            <div data-categories={post.category?._id || ''}>
-              <BlogCard post={post} />
-            </div>
+            <BlogCard post={post} />
           ))}
         </div>
       )}
 
-      {/* Empty state */}
-      {posts.length === 0 && (
+      <!-- Empty state -->
+      {page.data.length === 0 && (
         <div class="insights-list__empty">
           <p>No articles published yet. Check back soon for insights on design, development, and digital transformation.</p>
         </div>
       )}
+
+      <!-- Pagination -->
+      {page.lastPage > 1 && (
+        <nav class="pagination" aria-label="Article pages">
+          <a
+            href={page.url.prev ?? undefined}
+            class:list={['pagination__btn', 'pagination__btn--nav', { 'pagination__btn--disabled': !page.url.prev }]}
+            aria-disabled={!page.url.prev ? 'true' : undefined}
+            tabindex={!page.url.prev ? -1 : undefined}
+            aria-label="Previous page"
+          >
+            ←
+          </a>
+
+          {Array.from({ length: page.lastPage }, (_, i) => i + 1).map((num) => (
+            <a
+              href={num === 1 ? '/insights/' : `/insights/${num}/`}
+              class:list={['pagination__btn', { 'pagination__btn--active': num === page.currentPage }]}
+              aria-current={num === page.currentPage ? 'page' : undefined}
+            >
+              {num}
+            </a>
+          ))}
+
+          <a
+            href={page.url.next ?? undefined}
+            class:list={['pagination__btn', 'pagination__btn--nav', { 'pagination__btn--disabled': !page.url.next }]}
+            aria-disabled={!page.url.next ? 'true' : undefined}
+            tabindex={!page.url.next ? -1 : undefined}
+            aria-label="Next page"
+          >
+            →
+          </a>
+        </nav>
+      )}
+
     </div>
   </section>
 
@@ -167,7 +213,7 @@ const seoDescription = 'Expert insights on design, development, and digital tran
     color: var(--text-secondary);
     background: transparent;
     border: 1px solid var(--border);
-    cursor: pointer;
+    text-decoration: none;
     transition: all 0.3s ease;
   }
 
@@ -312,6 +358,62 @@ const seoDescription = 'Expert insights on design, development, and digital tran
     font-weight: 300;
   }
 
+  /* ---- Pagination ---- */
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    margin-top: 4rem;
+    padding-top: 2.5rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .pagination__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    height: 40px;
+    padding: 0 14px;
+    font-family: var(--font-body);
+    font-size: 12px;
+    font-weight: 400;
+    letter-spacing: 1px;
+    color: var(--text-secondary);
+    background: transparent;
+    border: 1px solid var(--border);
+    text-decoration: none;
+    transition: all 0.3s ease;
+  }
+
+  .pagination__btn:hover:not(.pagination__btn--disabled) {
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+
+  .pagination__btn--active {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.08);
+  }
+
+  .pagination__btn--nav {
+    font-size: 16px;
+    min-width: 44px;
+  }
+
+  .pagination__btn--disabled {
+    opacity: 0.3;
+    pointer-events: none;
+    cursor: default;
+  }
+
+  .pagination__btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
   /* ---- Responsive ---- */
   @media (max-width: 1024px) {
     .insights-list__grid {
@@ -343,6 +445,11 @@ const seoDescription = 'Expert insights on design, development, and digital tran
     .insights-list__grid {
       grid-template-columns: 1fr;
     }
+
+    .pagination {
+      margin-top: 3rem;
+      padding-top: 2rem;
+    }
   }
 
   @media (max-width: 480px) {
@@ -370,54 +477,12 @@ const seoDescription = 'Expert insights on design, development, and digital tran
     .featured-post__title {
       font-size: 1.375rem;
     }
+
+    .pagination__btn {
+      min-width: 36px;
+      height: 36px;
+      padding: 0 10px;
+      font-size: 11px;
+    }
   }
 </style>
-
-<script>
-  function initInsightsFilters() {
-    const pills = document.querySelectorAll<HTMLButtonElement>('.insights-list__pill');
-    const featuredPost = document.querySelector<HTMLElement>('.featured-post');
-    const gridItems = document.querySelectorAll<HTMLElement>('.insights-list__grid > div');
-
-    if (!pills.length) return;
-
-    pills.forEach((pill) => {
-      pill.addEventListener('click', () => {
-        const filter = pill.dataset.filter;
-
-        // Update active states
-        pills.forEach((p) => {
-          p.classList.remove('insights-list__pill--active');
-          p.setAttribute('aria-selected', 'false');
-        });
-        pill.classList.add('insights-list__pill--active');
-        pill.setAttribute('aria-selected', 'true');
-
-        // Filter featured post
-        if (featuredPost) {
-          if (filter === 'all') {
-            featuredPost.style.display = '';
-          } else {
-            const categories = featuredPost.dataset.categories || '';
-            const match = categories.split(',').includes(filter!);
-            featuredPost.style.display = match ? '' : 'none';
-          }
-        }
-
-        // Filter grid items
-        gridItems.forEach((item) => {
-          if (filter === 'all') {
-            item.style.display = '';
-            return;
-          }
-          const categories = item.dataset.categories || '';
-          const match = categories.split(',').includes(filter!);
-          item.style.display = match ? '' : 'none';
-        });
-      });
-    });
-  }
-
-  initInsightsFilters();
-  document.addEventListener('astro:after-swap', initInsightsFilters);
-</script>

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import BlogPostHero from '../../components/sections/BlogPostHero.astro';
+import BlogPostContent from '../../components/sections/BlogPostContent.astro';
+import AuthorBio from '../../components/sections/AuthorBio.astro';
+import RelatedPosts from '../../components/sections/RelatedPosts.astro';
+import CTASection from '../../components/sections/CTASection.astro';
+import { client, urlFor } from '../../lib/sanity';
+import { allBlogPostsQuery, blogPostBySlugQuery } from '../../lib/queries';
+
+export async function getStaticPaths() {
+  const posts = await client.fetch<Array<{ slug: { current: string } }>>(
+    `*[_type == "blogPost"] { slug }`
+  );
+
+  return posts.map((post) => ({
+    params: { slug: post.slug.current },
+  }));
+}
+
+const { slug } = Astro.params;
+
+const post = await client.fetch(blogPostBySlugQuery, { slug });
+
+if (!post) {
+  return Astro.redirect('/404');
+}
+
+// Build hero image URL
+let heroImageUrl: string | undefined;
+if (post.featuredImage) {
+  try {
+    heroImageUrl = urlFor(post.featuredImage).width(1920).format('webp').url();
+  } catch {
+    // No hero image available
+  }
+}
+
+// Prepare post data for hero
+const heroPost = {
+  title: post.title,
+  slug: post.slug,
+  category: post.category,
+  publishedAt: post.publishedAt,
+  readTime: post.readTime,
+  author: post.author,
+  heroImageUrl,
+};
+
+// Prepare author data with social links
+const authorData = post.author ? {
+  name: post.author.name,
+  role: post.author.role,
+  bio: post.author.bio,
+  photo: post.author.photo,
+  linkedin: post.author.linkedin,
+  twitter: post.author.twitter,
+} : undefined;
+
+const seoTitle = post.seoTitle || `${post.title}`;
+const seoDescription = post.seoDescription || post.excerpt;
+---
+
+<BaseLayout title={seoTitle} description={seoDescription}>
+  <BlogPostHero post={heroPost} />
+
+  {post.content && post.content.length > 0 && (
+    <BlogPostContent content={post.content} />
+  )}
+
+  {authorData && (
+    <AuthorBio author={authorData} />
+  )}
+
+  {post.relatedPosts && post.relatedPosts.length > 0 && (
+    <RelatedPosts posts={post.relatedPosts} />
+  )}
+
+  <CTASection
+    headline="Ready to *elevate* your digital presence?"
+    description="Let's discuss how we can help you achieve your business goals with the right strategy and technology."
+    buttonText="Start a Project"
+    buttonHref="/contact/"
+  />
+</BaseLayout>

--- a/src/pages/insights/category/[slug].astro
+++ b/src/pages/insights/category/[slug].astro
@@ -39,7 +39,7 @@ const allCategories = await client.fetch(allBlogCategoriesQuery);
 
 // Auto-select first post as featured
 const featuredPost = posts[0];
-const gridPosts = posts.slice(1, 7); // Show 6 more posts
+const gridPosts = posts.slice(1);
 
 let featuredImageUrl: string | undefined;
 if (featuredPost?.featuredImage) {

--- a/src/pages/insights/category/[slug].astro
+++ b/src/pages/insights/category/[slug].astro
@@ -1,0 +1,403 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import PageHero from '../../../components/sections/PageHero.astro';
+import SectionLabel from '../../../components/ui/SectionLabel.astro';
+import HighlightedText from '../../../components/ui/HighlightedText.astro';
+import BlogCard from '../../../components/cards/BlogCard.astro';
+import CTASection from '../../../components/sections/CTASection.astro';
+import { client, urlFor } from '../../../lib/sanity';
+import { allBlogCategoriesQuery, blogPostsByCategoryQuery } from '../../../lib/queries';
+import { formatDate } from '../../../lib/utils';
+
+export async function getStaticPaths() {
+  const categories = await client.fetch<Array<{ slug: { current: string } }>>(
+    `*[_type == "blogCategory"] { slug }`
+  );
+
+  return categories.map((cat) => ({
+    params: { slug: cat.slug.current },
+  }));
+}
+
+const { slug } = Astro.params;
+
+// Fetch category info
+const category = await client.fetch<{ title: string; description?: string } | null>(
+  `*[_type == "blogCategory" && slug.current == $slug][0] { title, description }`,
+  { slug }
+);
+
+if (!category) {
+  return Astro.redirect('/404');
+}
+
+// Fetch posts in this category
+const posts = await client.fetch(blogPostsByCategoryQuery, { categorySlug: slug });
+
+// Fetch all categories for filter pills
+const allCategories = await client.fetch(allBlogCategoriesQuery);
+
+// Auto-select first post as featured
+const featuredPost = posts[0];
+const gridPosts = posts.slice(1, 7); // Show 6 more posts
+
+let featuredImageUrl: string | undefined;
+if (featuredPost?.featuredImage) {
+  try {
+    featuredImageUrl = urlFor(featuredPost.featuredImage).width(1200).height(750).format('webp').url();
+  } catch {
+    // No image
+  }
+}
+
+const formattedFeaturedDate = featuredPost?.publishedAt ? formatDate(featuredPost.publishedAt) : undefined;
+
+const seoTitle = `${category.title} Articles`;
+const seoDescription = category.description || `Expert insights and articles about ${category.title.toLowerCase()}. Learn from our experience and practical knowledge.`;
+---
+
+<BaseLayout title={seoTitle} description={seoDescription}>
+  <PageHero variant="inner">
+    <SectionLabel text="Category" />
+    <h1>
+      <HighlightedText text={`*${category.title}* Articles`} />
+    </h1>
+    {category.description && (
+      <p class="page-hero__description">
+        {category.description}
+      </p>
+    )}
+  </PageHero>
+
+  <section class="insights-list">
+    <div class="insights-list__container">
+      <!-- Category filter pills -->
+      {allCategories && allCategories.length > 0 && (
+        <div class="insights-list__filters" role="tablist" aria-label="Filter articles by category">
+          <a href="/insights/" class="insights-list__pill" role="tab">
+            All
+          </a>
+          {allCategories.map((cat) => (
+            <a
+              href={`/insights/category/${cat.slug.current}/`}
+              class:list={['insights-list__pill', { 'insights-list__pill--active': cat.slug.current === slug }]}
+              role="tab"
+              aria-selected={cat.slug.current === slug ? 'true' : 'false'}
+            >
+              {cat.title}
+            </a>
+          ))}
+        </div>
+      )}
+
+      {posts.length > 0 ? (
+        <>
+          <!-- Featured post (large) -->
+          {featuredPost && (
+            <a
+              href={`/insights/${featuredPost.slug.current}/`}
+              class="featured-post"
+              style={featuredPost.slug?.current ? `view-transition-name: blog-card-${featuredPost.slug.current}` : undefined}
+            >
+              <div class="featured-post__image">
+                {featuredImageUrl ? (
+                  <img
+                    src={featuredImageUrl}
+                    alt={featuredPost.title}
+                    width="1200"
+                    height="750"
+                    loading="eager"
+                    style={featuredPost.slug?.current ? `view-transition-name: blog-hero-${featuredPost.slug.current}` : undefined}
+                  />
+                ) : (
+                  <div class="featured-post__placeholder" />
+                )}
+                <div class="featured-post__overlay" />
+              </div>
+              <div class="featured-post__content">
+                {featuredPost.category && (
+                  <span class="featured-post__category">{featuredPost.category.title}</span>
+                )}
+                <h2
+                  class="featured-post__title"
+                  style={featuredPost.slug?.current ? `view-transition-name: blog-title-${featuredPost.slug.current}` : undefined}
+                >
+                  {featuredPost.title}
+                </h2>
+                {featuredPost.excerpt && (
+                  <p class="featured-post__excerpt">{featuredPost.excerpt}</p>
+                )}
+                <div class="featured-post__meta">
+                  {formattedFeaturedDate && (
+                    <span>{formattedFeaturedDate}</span>
+                  )}
+                  {featuredPost.readTime && (
+                    <span>{featuredPost.readTime} read</span>
+                  )}
+                </div>
+              </div>
+            </a>
+          )}
+
+          <!-- Grid of posts -->
+          {gridPosts && gridPosts.length > 0 && (
+            <div class="insights-list__grid">
+              {gridPosts.map((post) => (
+                <BlogCard post={post} />
+              ))}
+            </div>
+          )}
+        </>
+      ) : (
+        <div class="insights-list__empty">
+          <p>No articles in this category yet. Check back soon for new insights.</p>
+        </div>
+      )}
+    </div>
+  </section>
+
+  <CTASection
+    headline="Ready to *elevate* your digital presence?"
+    description="Let's discuss how we can help you achieve your business goals with the right strategy and technology."
+    buttonText="Start a Project"
+    buttonHref="/contact/"
+  />
+</BaseLayout>
+
+<style>
+  .insights-list {
+    padding: 0 0 6rem;
+    background: var(--bg-primary);
+  }
+
+  .insights-list__container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  /* ---- Filter pills ---- */
+  .insights-list__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 3rem;
+  }
+
+  .insights-list__pill {
+    display: inline-block;
+    padding: 8px 20px;
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    background: transparent;
+    border: 1px solid var(--border);
+    text-decoration: none;
+    transition: all 0.3s ease;
+  }
+
+  .insights-list__pill:hover {
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+
+  .insights-list__pill--active {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.08);
+  }
+
+  .insights-list__pill:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* ---- Featured post ---- */
+  .featured-post {
+    display: block;
+    margin-bottom: 3rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-left: 3px solid transparent;
+    text-decoration: none;
+    overflow: hidden;
+    transition: border-color 0.3s ease, transform 0.3s ease;
+  }
+
+  .featured-post:hover {
+    border-left-color: var(--accent);
+    transform: translateY(-2px);
+  }
+
+  .featured-post__image {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+  }
+
+  .featured-post__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+
+  .featured-post:hover .featured-post__image img {
+    transform: scale(1.05);
+  }
+
+  .featured-post__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(10, 10, 10, 0.8) 0%, transparent 60%);
+    pointer-events: none;
+  }
+
+  .featured-post__placeholder {
+    width: 100%;
+    height: 100%;
+    background: var(--bg-tertiary);
+  }
+
+  .featured-post__content {
+    padding: 2rem 2.5rem 2.5rem;
+  }
+
+  .featured-post__category {
+    display: inline-block;
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.1);
+    padding: 6px 12px;
+    margin-bottom: 1rem;
+  }
+
+  .featured-post__title {
+    font-family: var(--font-display);
+    font-size: 2rem;
+    font-weight: 500;
+    line-height: 1.2;
+    color: var(--text-primary);
+    margin: 0 0 1rem;
+    transition: color 0.3s ease;
+  }
+
+  .featured-post:hover .featured-post__title {
+    color: var(--accent);
+  }
+
+  .featured-post__excerpt {
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    font-weight: 300;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0 0 1.5rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .featured-post__meta {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 300;
+    color: var(--text-muted);
+  }
+
+  .featured-post__meta span:not(:first-child)::before {
+    content: '•';
+    margin-right: 1.5rem;
+    color: var(--border-light);
+  }
+
+  /* ---- Posts grid ---- */
+  .insights-list__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+  }
+
+  /* ---- Empty state ---- */
+  .insights-list__empty {
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--text-secondary);
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    font-weight: 300;
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 1024px) {
+    .insights-list__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .insights-list {
+      padding: 0 0 4rem;
+    }
+
+    .insights-list__filters {
+      margin-bottom: 2rem;
+    }
+
+    .featured-post__content {
+      padding: 1.5rem 2rem 2rem;
+    }
+
+    .featured-post__title {
+      font-size: 1.5rem;
+    }
+
+    .featured-post__excerpt {
+      font-size: 1rem;
+    }
+
+    .insights-list__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .insights-list {
+      padding: 0 0 3rem;
+    }
+
+    .insights-list__container {
+      padding: 0 1rem;
+    }
+
+    .insights-list__filters {
+      gap: 0.375rem;
+    }
+
+    .insights-list__pill {
+      padding: 6px 14px;
+      font-size: 10px;
+    }
+
+    .featured-post__content {
+      padding: 1.25rem 1.5rem 1.5rem;
+    }
+
+    .featured-post__title {
+      font-size: 1.375rem;
+    }
+  }
+</style>

--- a/src/pages/insights/index.astro
+++ b/src/pages/insights/index.astro
@@ -1,0 +1,423 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHero from '../../components/sections/PageHero.astro';
+import SectionLabel from '../../components/ui/SectionLabel.astro';
+import HighlightedText from '../../components/ui/HighlightedText.astro';
+import BlogCard from '../../components/cards/BlogCard.astro';
+import CTASection from '../../components/sections/CTASection.astro';
+import { client, urlFor } from '../../lib/sanity';
+import { allBlogPostsQuery, allBlogCategoriesQuery } from '../../lib/queries';
+import { formatDate } from '../../lib/utils';
+
+const posts = await client.fetch(allBlogPostsQuery);
+const categories = await client.fetch(allBlogCategoriesQuery);
+
+// Auto-select first post as featured
+const featuredPost = posts[0];
+const gridPosts = posts.slice(1, 7); // Show 6 more posts (1 featured + 6 grid = 7 total)
+
+let featuredImageUrl: string | undefined;
+if (featuredPost?.featuredImage) {
+  try {
+    featuredImageUrl = urlFor(featuredPost.featuredImage).width(1200).height(750).format('webp').url();
+  } catch {
+    // No image
+  }
+}
+
+const formattedFeaturedDate = featuredPost?.publishedAt ? formatDate(featuredPost.publishedAt) : undefined;
+
+const seoTitle = 'Insights & Articles';
+const seoDescription = 'Expert insights on design, development, and digital transformation. Learn from our experience building digital products that drive business growth.';
+---
+
+<BaseLayout title={seoTitle} description={seoDescription}>
+  <PageHero variant="inner">
+    <SectionLabel text="Learn & Explore" />
+    <h1>
+      <HighlightedText text="Insights & *Articles*" />
+    </h1>
+    <p class="page-hero__description">
+      Expert perspectives on design, technology, and digital innovation.
+      Practical insights from real-world projects.
+    </p>
+  </PageHero>
+
+  <section class="insights-list">
+    <div class="insights-list__container">
+      <!-- Category filter pills -->
+      {categories && categories.length > 0 && (
+        <div class="insights-list__filters" role="tablist" aria-label="Filter articles by category">
+          <button class="insights-list__pill insights-list__pill--active" data-filter="all" role="tab" aria-selected="true">
+            All
+          </button>
+          {categories.map((cat) => (
+            <button class="insights-list__pill" data-filter={cat._id} role="tab" aria-selected="false">
+              {cat.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <!-- Featured post (large) -->
+      {featuredPost && (
+        <a
+          href={`/insights/${featuredPost.slug.current}/`}
+          class="featured-post"
+          data-categories={featuredPost.category?._id || ''}
+          style={featuredPost.slug?.current ? `view-transition-name: blog-card-${featuredPost.slug.current}` : undefined}
+        >
+          <div class="featured-post__image">
+            {featuredImageUrl ? (
+              <img
+                src={featuredImageUrl}
+                alt={featuredPost.title}
+                width="1200"
+                height="750"
+                loading="eager"
+                style={featuredPost.slug?.current ? `view-transition-name: blog-hero-${featuredPost.slug.current}` : undefined}
+              />
+            ) : (
+              <div class="featured-post__placeholder" />
+            )}
+            <div class="featured-post__overlay" />
+          </div>
+          <div class="featured-post__content">
+            {featuredPost.category && (
+              <span class="featured-post__category">{featuredPost.category.title}</span>
+            )}
+            <h2
+              class="featured-post__title"
+              style={featuredPost.slug?.current ? `view-transition-name: blog-title-${featuredPost.slug.current}` : undefined}
+            >
+              {featuredPost.title}
+            </h2>
+            {featuredPost.excerpt && (
+              <p class="featured-post__excerpt">{featuredPost.excerpt}</p>
+            )}
+            <div class="featured-post__meta">
+              {formattedFeaturedDate && (
+                <span>{formattedFeaturedDate}</span>
+              )}
+              {featuredPost.readTime && (
+                <span>{featuredPost.readTime} read</span>
+              )}
+            </div>
+          </div>
+        </a>
+      )}
+
+      <!-- Grid of posts -->
+      {gridPosts && gridPosts.length > 0 && (
+        <div class="insights-list__grid">
+          {gridPosts.map((post) => (
+            <div data-categories={post.category?._id || ''}>
+              <BlogCard post={post} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {posts.length === 0 && (
+        <div class="insights-list__empty">
+          <p>No articles published yet. Check back soon for insights on design, development, and digital transformation.</p>
+        </div>
+      )}
+    </div>
+  </section>
+
+  <CTASection
+    headline="Ready to *elevate* your digital presence?"
+    description="Let's discuss how we can help you achieve your business goals with the right strategy and technology."
+    buttonText="Start a Project"
+    buttonHref="/contact/"
+  />
+</BaseLayout>
+
+<style>
+  .insights-list {
+    padding: 0 0 6rem;
+    background: var(--bg-primary);
+  }
+
+  .insights-list__container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  /* ---- Filter pills ---- */
+  .insights-list__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 3rem;
+  }
+
+  .insights-list__pill {
+    display: inline-block;
+    padding: 8px 20px;
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    background: transparent;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: all 0.3s ease;
+  }
+
+  .insights-list__pill:hover {
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+
+  .insights-list__pill--active {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.08);
+  }
+
+  .insights-list__pill:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* ---- Featured post ---- */
+  .featured-post {
+    display: block;
+    margin-bottom: 3rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-left: 3px solid transparent;
+    text-decoration: none;
+    overflow: hidden;
+    transition: border-color 0.3s ease, transform 0.3s ease;
+  }
+
+  .featured-post:hover {
+    border-left-color: var(--accent);
+    transform: translateY(-2px);
+  }
+
+  .featured-post__image {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+  }
+
+  .featured-post__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+
+  .featured-post:hover .featured-post__image img {
+    transform: scale(1.05);
+  }
+
+  .featured-post__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(10, 10, 10, 0.8) 0%, transparent 60%);
+    pointer-events: none;
+  }
+
+  .featured-post__placeholder {
+    width: 100%;
+    height: 100%;
+    background: var(--bg-tertiary);
+  }
+
+  .featured-post__content {
+    padding: 2rem 2.5rem 2.5rem;
+  }
+
+  .featured-post__category {
+    display: inline-block;
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: rgba(201, 168, 124, 0.1);
+    padding: 6px 12px;
+    margin-bottom: 1rem;
+  }
+
+  .featured-post__title {
+    font-family: var(--font-display);
+    font-size: 2rem;
+    font-weight: 500;
+    line-height: 1.2;
+    color: var(--text-primary);
+    margin: 0 0 1rem;
+    transition: color 0.3s ease;
+  }
+
+  .featured-post:hover .featured-post__title {
+    color: var(--accent);
+  }
+
+  .featured-post__excerpt {
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    font-weight: 300;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0 0 1.5rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .featured-post__meta {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 300;
+    color: var(--text-muted);
+  }
+
+  .featured-post__meta span:not(:first-child)::before {
+    content: '•';
+    margin-right: 1.5rem;
+    color: var(--border-light);
+  }
+
+  /* ---- Posts grid ---- */
+  .insights-list__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+  }
+
+  /* ---- Empty state ---- */
+  .insights-list__empty {
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--text-secondary);
+    font-family: var(--font-body);
+    font-size: 1.125rem;
+    font-weight: 300;
+  }
+
+  /* ---- Responsive ---- */
+  @media (max-width: 1024px) {
+    .insights-list__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .insights-list {
+      padding: 0 0 4rem;
+    }
+
+    .insights-list__filters {
+      margin-bottom: 2rem;
+    }
+
+    .featured-post__content {
+      padding: 1.5rem 2rem 2rem;
+    }
+
+    .featured-post__title {
+      font-size: 1.5rem;
+    }
+
+    .featured-post__excerpt {
+      font-size: 1rem;
+    }
+
+    .insights-list__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .insights-list {
+      padding: 0 0 3rem;
+    }
+
+    .insights-list__container {
+      padding: 0 1rem;
+    }
+
+    .insights-list__filters {
+      gap: 0.375rem;
+    }
+
+    .insights-list__pill {
+      padding: 6px 14px;
+      font-size: 10px;
+    }
+
+    .featured-post__content {
+      padding: 1.25rem 1.5rem 1.5rem;
+    }
+
+    .featured-post__title {
+      font-size: 1.375rem;
+    }
+  }
+</style>
+
+<script>
+  function initInsightsFilters() {
+    const pills = document.querySelectorAll<HTMLButtonElement>('.insights-list__pill');
+    const featuredPost = document.querySelector<HTMLElement>('.featured-post');
+    const gridItems = document.querySelectorAll<HTMLElement>('.insights-list__grid > div');
+
+    if (!pills.length) return;
+
+    pills.forEach((pill) => {
+      pill.addEventListener('click', () => {
+        const filter = pill.dataset.filter;
+
+        // Update active states
+        pills.forEach((p) => {
+          p.classList.remove('insights-list__pill--active');
+          p.setAttribute('aria-selected', 'false');
+        });
+        pill.classList.add('insights-list__pill--active');
+        pill.setAttribute('aria-selected', 'true');
+
+        // Filter featured post
+        if (featuredPost) {
+          if (filter === 'all') {
+            featuredPost.style.display = '';
+          } else {
+            const categories = featuredPost.dataset.categories || '';
+            const match = categories.split(',').includes(filter!);
+            featuredPost.style.display = match ? '' : 'none';
+          }
+        }
+
+        // Filter grid items
+        gridItems.forEach((item) => {
+          if (filter === 'all') {
+            item.style.display = '';
+            return;
+          }
+          const categories = item.dataset.categories || '';
+          const match = categories.split(',').includes(filter!);
+          item.style.display = match ? '' : 'none';
+        });
+      });
+    });
+  }
+
+  initInsightsFilters();
+  document.addEventListener('astro:after-swap', initInsightsFilters);
+</script>


### PR DESCRIPTION
## Summary
Implements a fully functional blog system at `/insights` with editorial mixed layout, category filtering, and portable text content rendering.

## Changes
### Sanity Schema
- Added `readTime`, `featured`, and `tags` fields to `blogPost` schema
- Updated `blogPostBySlugQuery` to include author social links and SEO fields

### Components
- **BlogCard**: Card component with image, category pill, title, excerpt, date/read time
- **BlogPostHero**: Hero section with breadcrumb, metadata, and featured image
- **BlogPostContent**: Article body with 820px width and breakout effect for images
- **AuthorBio**: Minimal inline bio with 48px photo and social links
- **RelatedPosts**: 3-column grid of related articles

### Pages
- **`/insights/`**: Blog list with featured post + grid layout and category filtering
- **`/insights/[slug]/`**: Blog post detail page with content, author bio, and related posts
- **`/insights/category/[slug]/`**: Category-filtered blog list

## Design System Compliance
- ✅ CSS variables for colors
- ✅ Playfair Display for headings, Outfit for body
- ✅ 3px left border accent hover pattern
- ✅ View transitions for smooth navigation
- ✅ Responsive breakpoints (mobile, tablet, desktop)

## Testing
- [ ] Create test blog posts in Sanity Studio
- [ ] Verify featured post displays correctly on index
- [ ] Test category filtering functionality
- [ ] Check blog detail page renders all sections
- [ ] Verify author bio with social links
- [ ] Test related posts display

🤖 Generated with [Claude Code](https://claude.com/claude-code)