### PR TITLE
fix: migrate deployment from Cloudflare Pages to Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "wrangler pages dev dist/client",
+    "preview": "wrangler dev",
     "astro": "astro",
     "sanity:dev": "sanity dev",
     "sanity:deploy": "sanity deploy",
     "sanity:build": "sanity build",
-    "deploy": "npm run build && wrangler pages deploy dist/client",
-    "deploy:preview": "npm run build && wrangler pages deploy dist/client --branch preview"
+    "deploy": "npm run build && wrangler deploy",
+    "deploy:preview": "npm run build && wrangler versions upload"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.1.8",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,14 @@
-# Cloudflare Pages configuration
+# Cloudflare Workers configuration
+# @astrojs/cloudflare v13+ deploys via Workers (not Pages).
+# The adapter's @cloudflare/vite-plugin generates wrangler.json
+# in dist/server/ with the correct assets directory and entrypoint.
 name = "website"
 compatibility_date = "2026-02-11"
 compatibility_flags = ["nodejs_compat", "disable_nodejs_process_v2"]
+
+# 404 handling — serve 404.html for missing routes (like Pages did automatically)
+[assets]
+not_found_handling = "404-page"
 
 # Environment variables (available at build time + runtime)
 [vars]


### PR DESCRIPTION
## Summary

- `@astrojs/cloudflare` v13 uses `@cloudflare/vite-plugin` which deploys via **Workers**, not Pages
- Updated `wrangler.toml`: removed `pages_build_output_dir`, added `[assets] not_found_handling = "404-page"`
- Updated deploy scripts: `wrangler pages deploy` → `wrangler deploy`, `wrangler pages dev` → `wrangler dev`

## Dashboard steps after merge

1. Migrate Cloudflare project from Pages to Workers ([migration guide](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/))
2. Set up Workers Builds with Git integration for auto-deploy
3. Move any secrets (SANITY_API_TOKEN etc.) to Workers environment
4. Re-point custom domain to the new Workers project

## Test plan

- [x] `npm run build` completes successfully
- [ ] `npm run deploy` deploys via `wrangler deploy`
- [ ] 404 page renders correctly for missing routes
- [ ] `_redirects` and `_headers` work under Workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)