### PR TITLE
feat: add Sanity image schemas for About page and homepage section backgrounds

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,7 +44,6 @@ export default defineConfig({
       projectId: PUBLIC_SANITY_PROJECT_ID,
       dataset: PUBLIC_SANITY_DATASET || 'production',
       useCdn: false,
-      studioBasePath: '/studio',
     }),
   ],
   vite: {

--- a/docs/superpowers/specs/2026-04-13-about-page-sanity-images-design.md
+++ b/docs/superpowers/specs/2026-04-13-about-page-sanity-images-design.md
@@ -1,0 +1,79 @@
+# About Page — Sanity Image Fields
+
+**Date:** 2026-04-13
+**Scope:** Add `aboutPage` singleton schema for About page images; wire up frontend to use them
+
+## Context
+
+The PRD (section 5.8, line 469) specifies `aboutPage` as a Sanity data source, but the schema was never created. The About page (`src/pages/about.astro`) is entirely hardcoded. Photos exist on the shared drive (`I:\Shared drives\KP Infotech\Website\Website Images\`) that need a home in Sanity.
+
+This is an images-only pass. Text content stays hardcoded and can be migrated to Sanity later by extending this schema.
+
+## Schema: `aboutPage` (singleton)
+
+**File:** `sanity/schemas/aboutPage.ts`
+
+| Field | Sanity Type | Options | Purpose |
+|---|---|---|---|
+| `storyImage` | `image` | `hotspot: true` | Photo for the "Our Story" section (replaces current placeholder div) |
+| `craftIcon` | `image` | — | Value icon for "Craft" |
+| `partnershipIcon` | `image` | — | Value icon for "Partnership" |
+| `innovationIcon` | `image` | — | Value icon for "Innovation" |
+| `integrityIcon` | `image` | — | Value icon for "Integrity" |
+| `partnersImage` | `image` | `hotspot: true` | Image for "Trusted Partnerships" / Certifications section |
+
+Register in `sanity/schemas/index.ts`.
+
+Preview: static title "About Page".
+
+## Frontend Changes
+
+### `src/pages/about.astro`
+
+- Add GROQ query: `"aboutPage": *[_type == "aboutPage"][0] { storyImage, craftIcon, partnershipIcon, innovationIcon, integrityIcon, partnersImage }`
+- Build image URLs with `urlFor()` for each field (guard against null)
+- Pass `storyImageUrl` to `<OurStory>`
+- Override value icon paths: if Sanity URL exists, use it; otherwise fall back to static `/images/values/*.png`
+- Pass `partnersImageUrl` to `<Certifications>`
+
+### `src/components/sections/OurStory.astro`
+
+- Add `image?: string` prop (URL string)
+- When `image` is provided: render `<img>` with proper alt text, `loading="lazy"`, sized to fit the existing visual container (max-width 480px, aspect-ratio 4/5)
+- When `image` is absent: keep existing placeholder div (current behavior)
+
+### `src/components/sections/Values.astro`
+
+- No structural change — the `icon` field on each value object already accepts a URL string and renders an `<img>`
+- `about.astro` already passes icon paths; we just swap in Sanity URLs when available
+
+### `src/components/sections/Certifications.astro`
+
+- Add `sectionImage?: string` prop (URL string)
+- When provided: render as a visual alongside the certification badges (similar to the OurStory two-column pattern)
+- When absent: no change to current layout
+
+## What Stays the Same
+
+- All text content (story paragraphs, value titles/descriptions, certification names) remains hardcoded
+- `pageHeroes.aboutHero` continues handling the hero background image
+- Static files in `public/images/values/` remain as fallbacks
+- No changes to other pages or schemas
+
+## Image Mapping (Shared Drive to Schema Fields)
+
+| Shared Drive File | Schema Field |
+|---|---|
+| `About-our-story.jpg` | `storyImage` |
+| `craft-click-button.png` | `craftIcon` |
+| `partnership-deal.png` | `partnershipIcon` |
+| `innovation.png` | `innovationIcon` |
+| `integrity-badge.png` | `integrityIcon` |
+| `Trusted partners.jpg` | `partnersImage` |
+
+## Future Extension
+
+When text content moves to Sanity, add fields to this same `aboutPage` document:
+- `storyHeadline`, `storyParagraphs`, `founderNames`
+- Convert value icons to an array of `{ title, description, icon }` objects
+- `certifications[]` array of `{ name, description, logo, url }`

--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -5,4 +5,7 @@ export default defineCliConfig({
     projectId: '5rux0mv2',
     dataset: 'production',
   },
+  deployment: {
+    appId: 'nrhngkka32o4vdxu667lovc8',
+  },
 });

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -11,6 +11,7 @@ import { teamMember } from './schemas/teamMember';
 import { jobListing } from './schemas/jobListing';
 import { siteSettings } from './schemas/siteSettings';
 import { pageHeroes } from './schemas/pageHeroes';
+import { aboutPage } from './schemas/aboutPage';
 
 // Object schemas
 import { processStep } from './schemas/objects/processStep';
@@ -35,6 +36,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     jobListing,
     siteSettings,
     pageHeroes,
+    aboutPage,
     // Object types
     processStep,
     faqItem,

--- a/sanity/schemas/aboutPage.ts
+++ b/sanity/schemas/aboutPage.ts
@@ -1,0 +1,52 @@
+import { defineType, defineField } from 'sanity';
+
+export const aboutPage = defineType({
+  name: 'aboutPage',
+  title: 'About Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'storyImage',
+      type: 'image',
+      title: 'Our Story Image',
+      description: 'Photo for the "Our Story" section',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'craftIcon',
+      type: 'image',
+      title: 'Craft Value Icon',
+      description: 'Icon image for the "Craft" value card',
+    }),
+    defineField({
+      name: 'partnershipIcon',
+      type: 'image',
+      title: 'Partnership Value Icon',
+      description: 'Icon image for the "Partnership" value card',
+    }),
+    defineField({
+      name: 'innovationIcon',
+      type: 'image',
+      title: 'Innovation Value Icon',
+      description: 'Icon image for the "Innovation" value card',
+    }),
+    defineField({
+      name: 'integrityIcon',
+      type: 'image',
+      title: 'Integrity Value Icon',
+      description: 'Icon image for the "Integrity" value card',
+    }),
+    defineField({
+      name: 'partnersImage',
+      type: 'image',
+      title: 'Trusted Partners Image',
+      description: 'Image for the "Trusted Partnerships" / Certifications section',
+      options: { hotspot: true },
+    }),
+  ],
+  preview: {
+    prepare() {
+      return { title: 'About Page' };
+    },
+  },
+});

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -9,3 +9,4 @@ export { teamMember } from './teamMember';
 export { jobListing } from './jobListing';
 export { siteSettings } from './siteSettings';
 export { pageHeroes } from './pageHeroes';
+export { aboutPage } from './aboutPage';

--- a/sanity/schemas/pageHeroes.ts
+++ b/sanity/schemas/pageHeroes.ts
@@ -54,6 +54,27 @@ export const pageHeroes = defineType({
       description: 'Hero background image for the Insights (Blog) index page',
       options: { hotspot: true },
     }),
+    defineField({
+      name: 'homeServicesBg',
+      type: 'image',
+      title: 'Homepage — Services Background',
+      description: 'Background image for the Services section on the homepage',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'homeStatsBg',
+      type: 'image',
+      title: 'Homepage — Stats Background',
+      description: 'Background image for the Stats/Numbers section on the homepage',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'homeIndustriesBg',
+      type: 'image',
+      title: 'Homepage — Industries Background',
+      description: 'Background image for the Industries section on the homepage',
+      options: { hotspot: true },
+    }),
   ],
   preview: {
     prepare() {

--- a/src/components/sections/Certifications.astro
+++ b/src/components/sections/Certifications.astro
@@ -15,6 +15,7 @@ interface Props {
   label?: string;
   headline?: string;
   certifications?: Certification[];
+  sectionImage?: string;
 }
 
 const {
@@ -25,7 +26,8 @@ const {
       name: "Odoo Partner",
       description: "Official Odoo implementation and development partner, delivering enterprise ERP solutions."
     }
-  ]
+  ],
+  sectionImage,
 } = Astro.props;
 
 /**
@@ -41,7 +43,10 @@ function getLogoUrl(logo: SanityImageSource | undefined): string | null {
 }
 ---
 
-<section class="certifications">
+<section
+  class:list={["certifications", { "certifications--has-bg": !!sectionImage }]}
+  style={sectionImage ? `background-image: url(${sectionImage});` : undefined}
+>
   <div class="certifications__container">
     <header class="certifications__header">
       <SectionLabel text={label} variant="centered" />
@@ -83,13 +88,29 @@ function getLogoUrl(logo: SanityImageSource | undefined): string | null {
 <style>
   .certifications {
     padding: 6rem 0;
-    background: var(--bg-primary);
+    background-color: var(--bg-primary);
+    position: relative;
+  }
+
+  .certifications--has-bg {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  .certifications--has-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(10, 10, 10, 0.85);
   }
 
   .certifications__container {
     max-width: 900px;
     margin: 0 auto;
     padding: 0 1.5rem;
+    position: relative;
+    z-index: 1;
   }
 
   .certifications__header {

--- a/src/components/sections/IndustriesBento.astro
+++ b/src/components/sections/IndustriesBento.astro
@@ -14,16 +14,20 @@ interface Props {
     iconName?: string;
     iconCustom?: SanityImageSource;
   }>;
+  backgroundImage?: string;
 }
 
-const { industries = [] } = Astro.props;
+const { industries = [], backgroundImage } = Astro.props;
 
 // First industry is featured, rest are regular
 const featuredIndustry = industries[0];
 const regularIndustries = industries.slice(1);
 ---
 
-<section class="industries-bento">
+<section
+  class:list={["industries-bento", { "industries-bento--has-bg": !!backgroundImage }]}
+  style={backgroundImage ? `background-image: url(${backgroundImage});` : undefined}
+>
   <div class="industries-bento__container">
     <header class="industries-bento__header" data-reveal="fade">
       <SectionLabel text="Our Expertise" />
@@ -70,6 +74,20 @@ const regularIndustries = industries.slice(1);
 <style>
   .industries-bento {
     padding: 6rem 0;
+    position: relative;
+  }
+
+  .industries-bento--has-bg {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  .industries-bento--has-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(10, 10, 10, 0.85);
   }
 
   @media (max-width: 768px) {
@@ -88,6 +106,8 @@ const regularIndustries = industries.slice(1);
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 1.5rem;
+    position: relative;
+    z-index: 1;
   }
 
   /* ─── Header ─── */

--- a/src/components/sections/OurStory.astro
+++ b/src/components/sections/OurStory.astro
@@ -7,7 +7,7 @@ interface Props {
   headline?: string;
   paragraphs?: string[];
   founderNames?: string;
-  imagePlaceholder?: boolean;
+  image?: string;
 }
 
 const {
@@ -19,7 +19,7 @@ const {
     "Our approach combines strategic thinking with meticulous craftsmanship. Every project we take on receives our full attention, because we believe in quality over quantity."
   ],
   founderNames = "Krupa & Poojan",
-  imagePlaceholder = true
+  image,
 } = Astro.props;
 ---
 
@@ -40,12 +40,19 @@ const {
     </div>
 
     <div class="our-story__visual">
-      {imagePlaceholder ? (
+      {image ? (
+        <img
+          src={image}
+          alt="KP Infotech — Our Story"
+          class="our-story__image"
+          width="480"
+          height="600"
+          loading="lazy"
+        />
+      ) : (
         <div class="our-story__image-placeholder">
           <span>Image</span>
         </div>
-      ) : (
-        <slot name="image" />
       )}
     </div>
   </div>
@@ -121,6 +128,14 @@ const {
   .our-story__visual {
     display: flex;
     justify-content: center;
+  }
+
+  .our-story__image {
+    width: 100%;
+    max-width: 480px;
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    border: 1px solid var(--border);
   }
 
   .our-story__image-placeholder {

--- a/src/components/sections/RelatedServicesGrid.astro
+++ b/src/components/sections/RelatedServicesGrid.astro
@@ -17,11 +17,13 @@ interface ServiceItem {
 interface Props {
   heading?: string;
   services?: ServiceItem[];
+  backgroundImage?: string;
 }
 
 const {
   heading = 'Our *Services*',
   services: rawServices,
+  backgroundImage,
 } = Astro.props;
 
 const services = (rawServices || []).filter((s): s is ServiceItem => s != null && s.title != null);
@@ -46,7 +48,10 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
 ---
 
 {services.length > 0 && (
-  <section class="rsg">
+  <section
+    class:list={["rsg", { "rsg--has-bg": !!backgroundImage }]}
+    style={backgroundImage ? `background-image: url(${backgroundImage});` : undefined}
+  >
     <div class="rsg__container">
       <div class="rsg__header">
         <div>
@@ -103,12 +108,28 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
 <style>
   .rsg {
     padding: 6rem 0;
+    position: relative;
+  }
+
+  .rsg--has-bg {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  .rsg--has-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(10, 10, 10, 0.95);
   }
 
   .rsg__container {
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 1.5rem;
+    position: relative;
+    z-index: 1;
   }
 
   .rsg__header {

--- a/src/components/sections/StatsSection.astro
+++ b/src/components/sections/StatsSection.astro
@@ -7,12 +7,16 @@ interface Props {
     value: string;
     label: string;
   }>;
+  backgroundImage?: string;
 }
 
-const { stats } = Astro.props;
+const { stats, backgroundImage } = Astro.props;
 ---
 
-<section class="stats-section">
+<section
+  class:list={["stats-section", { "stats-section--has-bg": !!backgroundImage }]}
+  style={backgroundImage ? `background-image: url(${backgroundImage});` : undefined}
+>
   <div class="stats-section__container">
     <header class="stats-section__header">
       <SectionLabel text="By The Numbers" />
@@ -40,6 +44,20 @@ const { stats } = Astro.props;
 <style>
   .stats-section {
     padding: 6rem 0;
+    position: relative;
+  }
+
+  .stats-section--has-bg {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  .stats-section--has-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(10, 10, 10, 0.85);
   }
 
   @media (max-width: 768px) {
@@ -58,6 +76,8 @@ const { stats } = Astro.props;
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 1.5rem;
+    position: relative;
+    z-index: 1;
   }
 
   .stats-section__header {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -22,6 +22,14 @@ const aboutQuery = `{
   },
   "pageHeroes": *[_type == "pageHeroes"][0] {
     aboutHero
+  },
+  "aboutPage": *[_type == "aboutPage"][0] {
+    storyImage,
+    craftIcon,
+    partnershipIcon,
+    innovationIcon,
+    integrityIcon,
+    partnersImage
   }
 }`;
 
@@ -35,6 +43,14 @@ const data = await client.fetch<{
     linkedin?: string;
   }>;
   pageHeroes: { aboutHero?: any } | null;
+  aboutPage: {
+    storyImage?: any;
+    craftIcon?: any;
+    partnershipIcon?: any;
+    innovationIcon?: any;
+    integrityIcon?: any;
+    partnersImage?: any;
+  } | null;
 }>(aboutQuery);
 
 const teamMembers = data?.teamMembers || [];
@@ -47,6 +63,25 @@ if (data?.pageHeroes?.aboutHero) {
     aboutHeroUrl = urlFor(data.pageHeroes.aboutHero).width(1920).format('webp').url();
   } catch { /* fall back to placeholder */ }
 }
+
+// Build about page image URLs
+const ap = data?.aboutPage;
+
+function safeUrl(source: any, width: number, format: 'webp' | 'png' = 'webp'): string | undefined {
+  if (!source) return undefined;
+  try {
+    return urlFor(source).width(width).format(format).url();
+  } catch { return undefined; }
+}
+
+const storyImageUrl = safeUrl(ap?.storyImage, 960);
+const partnersImageUrl = safeUrl(ap?.partnersImage, 960);
+
+// Value icons — Sanity overrides static fallbacks
+const craftIconUrl = safeUrl(ap?.craftIcon, 144, 'png') || '/images/values/craft.png';
+const partnershipIconUrl = safeUrl(ap?.partnershipIcon, 144, 'png') || '/images/values/partnership.png';
+const innovationIconUrl = safeUrl(ap?.innovationIcon, 144, 'png') || '/images/values/innovation.png';
+const integrityIconUrl = safeUrl(ap?.integrityIcon, 144, 'png') || '/images/values/integrity.png';
 ---
 
 <BaseLayout
@@ -69,6 +104,7 @@ if (data?.pageHeroes?.aboutHero) {
       "Our approach combines strategic thinking with meticulous craftsmanship. Every project we take on receives our full attention, because we believe in quality over quantity."
     ]}
     founderNames="Krupa & Poojan"
+    image={storyImageUrl}
   />
 
   <Values
@@ -78,22 +114,22 @@ if (data?.pageHeroes?.aboutHero) {
       {
         title: "Craft",
         description: "We obsess over the details. Every pixel, every interaction, every line of code is crafted with intention and care.",
-        icon: "/images/values/craft.png"
+        icon: craftIconUrl
       },
       {
         title: "Partnership",
         description: "We don't just build for clients—we build with them. True collaboration creates the best outcomes.",
-        icon: "/images/values/partnership.png"
+        icon: partnershipIconUrl
       },
       {
         title: "Innovation",
         description: "We stay curious and embrace new technologies, always seeking better ways to solve problems.",
-        icon: "/images/values/innovation.png"
+        icon: innovationIconUrl
       },
       {
         title: "Integrity",
         description: "We're honest about what we can deliver, transparent in our process, and committed to doing what's right.",
-        icon: "/images/values/integrity.png"
+        icon: integrityIconUrl
       }
     ]}
   />
@@ -115,6 +151,7 @@ if (data?.pageHeroes?.aboutHero) {
         description: "Official Odoo implementation and development partner, delivering enterprise ERP solutions with certified expertise."
       }
     ]}
+    sectionImage={partnersImageUrl}
   />
 
   <CTASection

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import CTASection from '../components/sections/CTASection.astro';
 // Fetch all homepage data from Sanity
 const data = await client.fetch(homepageDataQuery);
 const pageHeroes = await client.fetch<Record<string, any> | null>(
-  `*[_type == "pageHeroes"][0] { homeHero }`
+  `*[_type == "pageHeroes"][0] { homeHero, homeServicesBg, homeStatsBg, homeIndustriesBg }`
 );
 
 const { siteSettings, services, industries, featuredWork, testimonials } = data;
@@ -28,6 +28,16 @@ if (pageHeroes?.homeHero) {
     homeHeroUrl = urlFor(pageHeroes.homeHero).width(1920).format('webp').url();
   } catch { /* fall back to local asset */ }
 }
+
+// Build section background URLs
+function safeBgUrl(source: any): string | undefined {
+  if (!source) return undefined;
+  try { return urlFor(source).width(1920).format('webp').url(); }
+  catch { return undefined; }
+}
+const servicesBgUrl = safeBgUrl(pageHeroes?.homeServicesBg);
+const statsBgUrl = safeBgUrl(pageHeroes?.homeStatsBg);
+const industriesBgUrl = safeBgUrl(pageHeroes?.homeIndustriesBg);
 
 // Prepare service names for marquee
 const serviceNames = services?.map((s: any) => s.title) || [
@@ -68,17 +78,17 @@ const heroDescription = "We craft premium digital experiences for startups and b
 
   <!-- Services Grid -->
   {services && services.length > 0 && (
-    <RelatedServicesGrid services={services} />
+    <RelatedServicesGrid services={services} backgroundImage={servicesBgUrl} />
   )}
 
   <!-- Stats Section -->
   {stats && stats.length > 0 && (
-    <StatsSection stats={stats} />
+    <StatsSection stats={stats} backgroundImage={statsBgUrl} />
   )}
 
   <!-- Industries Bento -->
   {industries && industries.length > 0 && (
-    <IndustriesBento industries={industries} />
+    <IndustriesBento industries={industries} backgroundImage={industriesBgUrl} />
   )}
 
   <!-- Testimonials Carousel -->


### PR DESCRIPTION
## Summary
- Create `aboutPage` singleton schema with image fields for About page (story image, 4 value icons, partners image)
- Add 3 homepage section background fields to `pageHeroes` schema (services, stats, industries)
- Wire up `about.astro`, `index.astro`, and 5 section components (`OurStory`, `Certifications`, `RelatedServicesGrid`, `StatsSection`, `IndustriesBento`) to consume Sanity images with dark overlay backgrounds
- Static fallbacks preserved — sections render identically when no images are uploaded

## Test plan
- [ ] Run `npm run sanity:dev` and verify "About Page" and updated "Page Heroes" documents appear in Studio
- [ ] Upload images to About Page fields, confirm they render on `/about/`
- [ ] Upload section backgrounds to Page Heroes, confirm overlays on homepage sections
- [ ] Verify pages render correctly with no images uploaded (fallback behavior)
- [ ] Run `npm run build` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)