### PR TITLE
feat: align all sections to header container + centralize with .site-container

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -76,7 +76,7 @@ const socials = [
 ---
 
 <footer class="bg-[var(--bg-secondary)] border-t border-[var(--border)]">
-  <div class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-20">
+  <div class="max-w-[1440px] mx-auto px-6 lg:px-12 py-16 lg:py-20">
     <!-- Main Footer Grid -->
     <div class="footer-grid">
       <!-- Column 1: Logo + Tagline + Social -->
@@ -242,7 +242,7 @@ const socials = [
 
 <style>
   .footer-logo {
-    height: 40px;
+    height: 80px;
     width: auto;
   }
 

--- a/src/components/sections/AuthorBio.astro
+++ b/src/components/sections/AuthorBio.astro
@@ -26,7 +26,7 @@ if (author.photo) {
 ---
 
 <section class="author-bio">
-  <div class="author-bio__container">
+  <div class="author-bio__container site-container">
     <div class="author-bio__content">
       <div class="author-bio__profile">
         {photoUrl ? (
@@ -91,10 +91,6 @@ if (author.photo) {
   }
 
   .author-bio__container {
-    width: 100%;
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .author-bio__content {
@@ -208,10 +204,6 @@ if (author.photo) {
   }
 
   @media (max-width: 480px) {
-    .author-bio__container {
-      padding: 0 1rem;
-    }
-
     .author-bio__content {
       padding: 1.5rem 0;
     }

--- a/src/components/sections/BlogPostContent.astro
+++ b/src/components/sections/BlogPostContent.astro
@@ -25,7 +25,7 @@ const hasContent = content && content.length > 0;
 
 {hasContent && (
   <section class="blog-content">
-    <div class="blog-content__container">
+    <div class="blog-content__container site-container">
       <article class="blog-content__body">
         <PortableText value={content} components={components} />
       </article>
@@ -41,10 +41,6 @@ const hasContent = content && content.length > 0;
   }
 
   .blog-content__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .blog-content__body {
@@ -237,23 +233,12 @@ const hasContent = content && content.length > 0;
       padding: 3rem 0;
     }
 
-    .blog-content__container {
-      padding: 0 1rem;
-    }
-
     .blog-content__body :global(.portable-text-image) {
       margin: 1.5rem -1rem;
     }
 
     .blog-content__body :global(.portable-text-image figcaption) {
       padding: 0 1rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .blog-content__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/BlogPostContent.astro
+++ b/src/components/sections/BlogPostContent.astro
@@ -42,7 +42,7 @@ const hasContent = content && content.length > 0;
 
   .blog-content__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -247,6 +247,13 @@ const hasContent = content && content.length > 0;
 
     .blog-content__body :global(.portable-text-image figcaption) {
       padding: 0 1rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .blog-content__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/CTASection.astro
+++ b/src/components/sections/CTASection.astro
@@ -18,7 +18,7 @@ const {
 ---
 
 <section class="cta-section">
-  <div class="cta-section__container">
+  <div class="cta-section__container site-container">
     <div class="cta-section__card" data-reveal="clip">
       <h2 class="cta-section__headline"><HighlightedText text={headline} /></h2>
       <p class="cta-section__description">{description}</p>
@@ -33,13 +33,6 @@ const {
   .cta-section {
     padding: 6rem 0;
     background: var(--bg-primary);
-  }
-
-  .cta-section__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .cta-section__card {
@@ -95,10 +88,4 @@ const {
     }
   }
 
-  @media (min-width: 1024px) {
-    .cta-section__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/CTASection.astro
+++ b/src/components/sections/CTASection.astro
@@ -37,14 +37,12 @@ const {
 
   .cta-section__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
 
   .cta-section__card {
-    max-width: 900px;
-    margin: 0 auto;
     padding: 5rem 4rem;
     background: var(--bg-secondary);
     border: 1px solid var(--accent);
@@ -94,6 +92,13 @@ const {
   @media (max-width: 480px) {
     .cta-section__card {
       padding: 2.5rem 1.5rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .cta-section__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/CaseStudyContent.astro
+++ b/src/components/sections/CaseStudyContent.astro
@@ -42,7 +42,7 @@ const hasContent = content && content.length > 0;
 
   .case-content__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -160,7 +160,7 @@ const hasContent = content && content.length > 0;
   /* ---- Images: magazine breakout ---- */
   .case-content__body :global(.portable-text-image) {
     width: 100vw;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 2.5rem 0;
     position: relative;
     left: 50%;
@@ -219,6 +219,13 @@ const hasContent = content && content.length > 0;
 
     .case-content__container {
       padding: 0 1rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .case-content__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/CaseStudyContent.astro
+++ b/src/components/sections/CaseStudyContent.astro
@@ -25,7 +25,7 @@ const hasContent = content && content.length > 0;
 
 {hasContent && (
   <section class="case-content">
-    <div class="case-content__container">
+    <div class="case-content__container site-container">
       <div class="case-content__body">
         <PortableText value={content} components={components} />
       </div>
@@ -41,10 +41,6 @@ const hasContent = content && content.length > 0;
   }
 
   .case-content__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .case-content__body {
@@ -215,17 +211,6 @@ const hasContent = content && content.length > 0;
   @media (max-width: 480px) {
     .case-content {
       padding: 3rem 0;
-    }
-
-    .case-content__container {
-      padding: 0 1rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .case-content__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/Certifications.astro
+++ b/src/components/sections/Certifications.astro
@@ -47,7 +47,7 @@ function getLogoUrl(logo: SanityImageSource | undefined): string | null {
   class:list={["certifications", { "certifications--has-bg": !!sectionImage }]}
   style={sectionImage ? `background-image: url(${sectionImage});` : undefined}
 >
-  <div class="certifications__container">
+  <div class="certifications__container site-container">
     <header class="certifications__header">
       <SectionLabel text={label} variant="centered" />
       <h2 class="certifications__headline"><HighlightedText text={headline} /></h2>
@@ -106,9 +106,6 @@ function getLogoUrl(logo: SanityImageSource | undefined): string | null {
   }
 
   .certifications__container {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     position: relative;
     z-index: 1;
   }

--- a/src/components/sections/ContactFormSection.astro
+++ b/src/components/sections/ContactFormSection.astro
@@ -58,7 +58,7 @@ const budgetRanges = [
 ---
 
 <section class="contact-form-section">
-  <div class="contact-form-section__container">
+  <div class="contact-form-section__container site-container">
     <!-- Contact Info Sidebar -->
     <aside class="contact-info">
       <h2 class="contact-info__title">Contact Details</h2>
@@ -253,9 +253,6 @@ const budgetRanges = [
   }
 
   .contact-form-section__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     display: grid;
     grid-template-columns: 320px 1fr;
     gap: 3rem;
@@ -576,10 +573,6 @@ const budgetRanges = [
       padding: 2rem 0 3rem;
     }
 
-    .contact-form-section__container {
-      padding: 0 1rem;
-    }
-
     .contact-info,
     .contact-form-wrapper {
       padding: 1.5rem;
@@ -588,13 +581,6 @@ const budgetRanges = [
     .contact-info__title,
     .contact-form__title {
       font-size: 1.25rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .contact-form-section__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/ContactFormSection.astro
+++ b/src/components/sections/ContactFormSection.astro
@@ -253,7 +253,7 @@ const budgetRanges = [
   }
 
   .contact-form-section__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     display: grid;
@@ -588,6 +588,13 @@ const budgetRanges = [
     .contact-info__title,
     .contact-form__title {
       font-size: 1.25rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .contact-form-section__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/FeaturedWork.astro
+++ b/src/components/sections/FeaturedWork.astro
@@ -33,7 +33,7 @@ function getImageUrl(image: any): string | null {
 ---
 
 <section class="featured-work">
-  <div class="featured-work__container">
+  <div class="featured-work__container site-container">
     <header class="featured-work__header">
       <SectionLabel text="Selected Work" />
       <h2 class="featured-work__title"><HighlightedText text="Featured *Projects*" /></h2>
@@ -97,12 +97,6 @@ function getImageUrl(image: any): string | null {
   .featured-work {
     padding: 6rem 0;
     background: var(--bg-primary);
-  }
-
-  .featured-work__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .featured-work__header {
@@ -301,19 +295,9 @@ function getImageUrl(image: any): string | null {
       padding: 3rem 0;
     }
 
-    .featured-work__container {
-      padding: 0 1rem;
-    }
-
     .empty-card {
       padding: 2rem 1.25rem;
     }
   }
 
-  @media (min-width: 1024px) {
-    .featured-work__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/FeaturedWork.astro
+++ b/src/components/sections/FeaturedWork.astro
@@ -24,7 +24,8 @@ const hasCaseStudies = caseStudies.length > 0;
 function getImageUrl(image: any): string | null {
   if (!image) return null;
   try {
-    return urlFor(image).url();
+    // Pre-crop to 16:10 at Sanity CDN so Astro doesn't letterbox
+    return urlFor(image).width(1600).height(1000).fit('crop').url();
   } catch {
     return null;
   }
@@ -50,11 +51,12 @@ function getImageUrl(image: any): string | null {
                 <SanityPicture
                   src={imageUrl}
                   alt={caseStudy.title}
-                  width={600}
-                  height={375}
+                  width={800}
+                  height={500}
                   sizes="(max-width: 768px) 100vw, 50vw"
                   class="work-card__image"
                   loading="lazy"
+                  fill
                 />
               ) : (
                 <div class="work-card__placeholder"></div>
@@ -98,7 +100,7 @@ function getImageUrl(image: any): string | null {
   }
 
   .featured-work__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -161,20 +163,7 @@ function getImageUrl(image: any): string | null {
     overflow: hidden;
   }
 
-  .work-card__image {
-    display: block;
-    width: 100%;
-    height: 100%;
-  }
-
-  .work-card__image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 0.5s ease;
-  }
-
-  .work-card:hover .work-card__image img {
+  .work-card:hover .work-card__image-wrapper :global(img) {
     transform: scale(1.05);
   }
 
@@ -318,6 +307,13 @@ function getImageUrl(image: any): string | null {
 
     .empty-card {
       padding: 2rem 1.25rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .featured-work__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/IndustriesBento.astro
+++ b/src/components/sections/IndustriesBento.astro
@@ -28,7 +28,7 @@ const regularIndustries = industries.slice(1);
   class:list={["industries-bento", { "industries-bento--has-bg": !!backgroundImage }]}
   style={backgroundImage ? `background-image: url(${backgroundImage});` : undefined}
 >
-  <div class="industries-bento__container">
+  <div class="industries-bento__container site-container">
     <header class="industries-bento__header" data-reveal="fade">
       <SectionLabel text="Our Expertise" />
       <h2 class="industries-bento__title">
@@ -103,9 +103,6 @@ const regularIndustries = industries.slice(1);
   }
 
   .industries-bento__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     position: relative;
     z-index: 1;
   }
@@ -178,11 +175,6 @@ const regularIndustries = industries.slice(1);
 
   /* Desktop: Classic bento layout */
   @media (min-width: 1024px) {
-    .industries-bento__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-
     .industries-bento__grid {
       grid-template-columns: 1.3fr 1fr 1fr;
       grid-template-rows: auto auto;

--- a/src/components/sections/IndustriesBento.astro
+++ b/src/components/sections/IndustriesBento.astro
@@ -103,7 +103,7 @@ const regularIndustries = industries.slice(1);
   }
 
   .industries-bento__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     position: relative;
@@ -178,6 +178,11 @@ const regularIndustries = industries.slice(1);
 
   /* Desktop: Classic bento layout */
   @media (min-width: 1024px) {
+    .industries-bento__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
     .industries-bento__grid {
       grid-template-columns: 1.3fr 1fr 1fr;
       grid-template-rows: auto auto;

--- a/src/components/sections/IndustryChallenges.astro
+++ b/src/components/sections/IndustryChallenges.astro
@@ -67,7 +67,7 @@ const challenges = (rawChallenges || []).filter((c): c is ChallengeItem => c != 
   }
 
   .tension__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -285,6 +285,13 @@ const challenges = (rawChallenges || []).filter((c): c is ChallengeItem => c != 
 
     .ghost-text {
       font-size: 3.5rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .tension__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 

--- a/src/components/sections/IndustryChallenges.astro
+++ b/src/components/sections/IndustryChallenges.astro
@@ -24,7 +24,7 @@ const challenges = (rawChallenges || []).filter((c): c is ChallengeItem => c != 
 
 {challenges.length > 0 && (
   <section class="tension">
-    <div class="tension__container">
+    <div class="tension__container site-container">
       <div class="tension__head">
         <SectionLabel text="Challenges" />
         <h2 class="tension__title"><HighlightedText text={heading} /></h2>
@@ -67,9 +67,6 @@ const challenges = (rawChallenges || []).filter((c): c is ChallengeItem => c != 
   }
 
   .tension__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .tension__head {
@@ -285,13 +282,6 @@ const challenges = (rawChallenges || []).filter((c): c is ChallengeItem => c != 
 
     .ghost-text {
       font-size: 3.5rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .tension__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
     }
   }
 

--- a/src/components/sections/IndustrySolutions.astro
+++ b/src/components/sections/IndustrySolutions.astro
@@ -92,7 +92,7 @@ const rightSolutions = solutions.filter((_, i) => i % 2 !== 0);
   }
 
   .orbit__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -261,6 +261,13 @@ const rightSolutions = solutions.filter((_, i) => i % 2 !== 0);
 
     .orbit-card {
       padding: 1.5rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .orbit__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 

--- a/src/components/sections/IndustrySolutions.astro
+++ b/src/components/sections/IndustrySolutions.astro
@@ -31,7 +31,7 @@ const rightSolutions = solutions.filter((_, i) => i % 2 !== 0);
 
 {solutions.length > 0 && (
   <section class="orbit">
-    <div class="orbit__container">
+    <div class="orbit__container site-container">
       <div class="orbit__head">
         <SectionLabel text="Solutions" />
         <h2 class="orbit__title"><HighlightedText text={heading} /></h2>
@@ -92,9 +92,6 @@ const rightSolutions = solutions.filter((_, i) => i % 2 !== 0);
   }
 
   .orbit__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .orbit__head {
@@ -261,13 +258,6 @@ const rightSolutions = solutions.filter((_, i) => i % 2 !== 0);
 
     .orbit-card {
       padding: 1.5rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .orbit__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
     }
   }
 

--- a/src/components/sections/NextProject.astro
+++ b/src/components/sections/NextProject.astro
@@ -27,7 +27,7 @@ const hasProject = project?.title && project?.slug;
 {hasProject && (
   <section class="next-project">
     <a href={`/work/${project.slug!.current}/`} class="next-project__link">
-      <div class="next-project__container">
+      <div class="next-project__container site-container">
         <div class="next-project__text">
           <SectionLabel text="Next Project" />
           <h2 class="next-project__title">{project.title}</h2>
@@ -80,10 +80,6 @@ const hasProject = project?.title && project?.slug;
   }
 
   .next-project__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 3rem;
@@ -209,15 +205,5 @@ const hasProject = project?.title && project?.slug;
       padding: 3rem 0;
     }
 
-    .next-project__container {
-      padding: 0 1rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .next-project__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
   }
 </style>

--- a/src/components/sections/NextProject.astro
+++ b/src/components/sections/NextProject.astro
@@ -81,7 +81,7 @@ const hasProject = project?.title && project?.slug;
 
   .next-project__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     display: grid;
@@ -211,6 +211,13 @@ const hasProject = project?.title && project?.slug;
 
     .next-project__container {
       padding: 0 1rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .next-project__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/OurStory.astro
+++ b/src/components/sections/OurStory.astro
@@ -68,7 +68,7 @@ const {
   }
 
   .our-story__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     display: grid;
@@ -182,6 +182,8 @@ const {
     .our-story__container {
       grid-template-columns: 1fr 1fr;
       gap: 6rem;
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
 
     .our-story__content {

--- a/src/components/sections/OurStory.astro
+++ b/src/components/sections/OurStory.astro
@@ -24,7 +24,7 @@ const {
 ---
 
 <section class="our-story">
-  <div class="our-story__container">
+  <div class="our-story__container site-container">
     <div class="our-story__content">
       <SectionLabel text={label} />
       <h2 class="our-story__headline"><HighlightedText text={headline} /></h2>
@@ -68,9 +68,6 @@ const {
   }
 
   .our-story__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     display: grid;
     grid-template-columns: 1fr;
     gap: 4rem;
@@ -182,8 +179,6 @@ const {
     .our-story__container {
       grid-template-columns: 1fr 1fr;
       gap: 6rem;
-      padding-left: 3rem;
-      padding-right: 3rem;
     }
 
     .our-story__content {

--- a/src/components/sections/PageHero.astro
+++ b/src/components/sections/PageHero.astro
@@ -201,10 +201,5 @@ const resolvedImage = image || heroPlaceholder;
     }
   }
 
-  /* Large desktop: 1280px+ */
-  @media (min-width: 1280px) {
-    .page-hero__container {
-      padding: 0 5rem;
-    }
-  }
+  /* Large desktop: 1280px+ — keep same padding as header (3rem) */
 </style>

--- a/src/components/sections/ProjectOverview.astro
+++ b/src/components/sections/ProjectOverview.astro
@@ -63,7 +63,7 @@ const hasContent = blocks.length > 0;
 
   .project-overview__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -201,6 +201,13 @@ const hasContent = blocks.length > 0;
 
     .overview-block {
       padding-left: 1rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .project-overview__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/ProjectOverview.astro
+++ b/src/components/sections/ProjectOverview.astro
@@ -28,7 +28,7 @@ const hasContent = blocks.length > 0;
 
 {hasContent && (
   <section class="project-overview">
-    <div class="project-overview__container">
+    <div class="project-overview__container site-container">
       <SectionLabel text="Project Overview" />
       <h2 class="project-overview__title">How we got there</h2>
 
@@ -62,10 +62,6 @@ const hasContent = blocks.length > 0;
   }
 
   .project-overview__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .project-overview__title {
@@ -195,19 +191,9 @@ const hasContent = blocks.length > 0;
       padding: 3rem 0;
     }
 
-    .project-overview__container {
-      padding: 0 1rem;
-    }
-
     .overview-block {
       padding-left: 1rem;
     }
   }
 
-  @media (min-width: 1024px) {
-    .project-overview__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/ProjectTestimonial.astro
+++ b/src/components/sections/ProjectTestimonial.astro
@@ -25,7 +25,7 @@ const hasTestimonial = testimonial?.quote;
 
 {hasTestimonial && (
   <section class="project-testimonial">
-    <div class="project-testimonial__container">
+    <div class="project-testimonial__container site-container">
       <div class="project-testimonial__card">
         <blockquote class="project-testimonial__quote">
           <p>&ldquo;{testimonial.quote}&rdquo;</p>
@@ -65,10 +65,6 @@ const hasTestimonial = testimonial?.quote;
   }
 
   .project-testimonial__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .project-testimonial__card {
@@ -143,19 +139,9 @@ const hasTestimonial = testimonial?.quote;
       padding: 3rem 0;
     }
 
-    .project-testimonial__container {
-      padding: 0 1rem;
-    }
-
     .project-testimonial__card {
       padding: 1.5rem 1.5rem 1.5rem calc(1.5rem + 4px);
     }
   }
 
-  @media (min-width: 1024px) {
-    .project-testimonial__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/ProjectTestimonial.astro
+++ b/src/components/sections/ProjectTestimonial.astro
@@ -66,7 +66,7 @@ const hasTestimonial = testimonial?.quote;
 
   .project-testimonial__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -149,6 +149,13 @@ const hasTestimonial = testimonial?.quote;
 
     .project-testimonial__card {
       padding: 1.5rem 1.5rem 1.5rem calc(1.5rem + 4px);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .project-testimonial__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/RelatedPosts.astro
+++ b/src/components/sections/RelatedPosts.astro
@@ -20,7 +20,7 @@ const { posts } = Astro.props;
 
 {posts && posts.length > 0 && (
   <section class="related-posts">
-    <div class="related-posts__container">
+    <div class="related-posts__container site-container">
       <div class="related-posts__header">
         <SectionLabel text="Related" />
         <h2>Related Articles</h2>
@@ -42,10 +42,6 @@ const { posts } = Astro.props;
   }
 
   .related-posts__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .related-posts__header {
@@ -93,19 +89,9 @@ const { posts } = Astro.props;
       padding: 3rem 0;
     }
 
-    .related-posts__container {
-      padding: 0 1rem;
-    }
-
     .related-posts__header {
       margin-bottom: 2rem;
     }
   }
 
-  @media (min-width: 1024px) {
-    .related-posts__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/RelatedPosts.astro
+++ b/src/components/sections/RelatedPosts.astro
@@ -43,7 +43,7 @@ const { posts } = Astro.props;
 
   .related-posts__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -99,6 +99,13 @@ const { posts } = Astro.props;
 
     .related-posts__header {
       margin-bottom: 2rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .related-posts__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/RelatedServicesGrid.astro
+++ b/src/components/sections/RelatedServicesGrid.astro
@@ -52,7 +52,7 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
     class:list={["rsg", { "rsg--has-bg": !!backgroundImage }]}
     style={backgroundImage ? `background-image: url(${backgroundImage});` : undefined}
   >
-    <div class="rsg__container">
+    <div class="rsg__container site-container">
       <div class="rsg__header">
         <div>
           <SectionLabel text="What We Do" />
@@ -125,9 +125,6 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
   }
 
   .rsg__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     position: relative;
     z-index: 1;
   }
@@ -298,11 +295,6 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
   }
 
   @media (min-width: 1024px) {
-    .rsg__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-
     .rsg__grid {
       grid-template-columns: repeat(3, 1fr);
       gap: 2rem;

--- a/src/components/sections/RelatedServicesGrid.astro
+++ b/src/components/sections/RelatedServicesGrid.astro
@@ -125,7 +125,7 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
   }
 
   .rsg__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     position: relative;
@@ -298,6 +298,11 @@ function getHeroUrl(image: SanityImageSource | undefined): string | null {
   }
 
   @media (min-width: 1024px) {
+    .rsg__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
     .rsg__grid {
       grid-template-columns: repeat(3, 1fr);
       gap: 2rem;

--- a/src/components/sections/ResultsStrip.astro
+++ b/src/components/sections/ResultsStrip.astro
@@ -14,7 +14,7 @@ const hasResults = results && results.length > 0;
 
 {hasResults && (
   <section class="results-strip">
-    <div class="results-strip__container">
+    <div class="results-strip__container site-container">
       {results.map((result) => (
         <div class="results-strip__item">
           <span class="results-strip__metric" data-metric={result.metric}>
@@ -36,10 +36,6 @@ const hasResults = results && results.length > 0;
   }
 
   .results-strip__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     display: flex;
     justify-content: space-evenly;
     align-items: center;
@@ -99,12 +95,6 @@ const hasResults = results && results.length > 0;
     }
   }
 
-  @media (min-width: 1024px) {
-    .results-strip__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>
 
 <script>

--- a/src/components/sections/ResultsStrip.astro
+++ b/src/components/sections/ResultsStrip.astro
@@ -37,7 +37,7 @@ const hasResults = results && results.length > 0;
 
   .results-strip__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     display: flex;
@@ -96,6 +96,13 @@ const hasResults = results && results.length > 0;
 
     .results-strip__item {
       flex: none;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .results-strip__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/ServiceContent.astro
+++ b/src/components/sections/ServiceContent.astro
@@ -52,6 +52,13 @@ const components = {
     padding: 0 1.5rem;
   }
 
+  @media (min-width: 1024px) {
+    .service-content__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+  }
+
   .service-content__title {
     font-family: var(--font-display);
     font-size: clamp(2rem, 5vw, 3rem);

--- a/src/components/sections/ServiceFAQ.astro
+++ b/src/components/sections/ServiceFAQ.astro
@@ -22,7 +22,7 @@ const {
 
 {faqs && faqs.length > 0 && (
   <section class="service-faq">
-    <div class="service-faq__container">
+    <div class="service-faq__container site-container">
       <div class="service-faq__layout">
         {/* Left: Sticky header */}
         <div class="service-faq__sidebar">
@@ -70,10 +70,6 @@ const {
   }
 
   .service-faq__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   /* Two-column layout */
@@ -208,10 +204,4 @@ const {
     }
   }
 
-  @media (min-width: 1024px) {
-    .service-faq__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/ServiceFAQ.astro
+++ b/src/components/sections/ServiceFAQ.astro
@@ -71,7 +71,7 @@ const {
 
   .service-faq__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -205,6 +205,13 @@ const {
 
     .faq-item__question {
       padding: 1.25rem 0;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .service-faq__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/ServiceProcess.astro
+++ b/src/components/sections/ServiceProcess.astro
@@ -84,7 +84,7 @@ const detailLabels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
   .blueprint__container {
     width: 100%;
-    max-width: 1400px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -366,6 +366,13 @@ const detailLabels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
     .blueprint-card__desc {
       font-size: 0.9375rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .blueprint__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/ServiceProcess.astro
+++ b/src/components/sections/ServiceProcess.astro
@@ -25,7 +25,7 @@ const detailLabels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 {steps && steps.length > 0 && (
   <section class="blueprint">
-    <div class="blueprint__container">
+    <div class="blueprint__container site-container">
       <div class="blueprint__header">
         <SectionLabel text="Our Process" />
         <h2 class="blueprint__title">
@@ -83,10 +83,6 @@ const detailLabels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   }
 
   .blueprint__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .blueprint__header {
@@ -369,10 +365,4 @@ const detailLabels = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     }
   }
 
-  @media (min-width: 1024px) {
-    .blueprint__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/ServiceTechMarquee.astro
+++ b/src/components/sections/ServiceTechMarquee.astro
@@ -38,7 +38,7 @@ const {
 
   .service-tech__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -90,6 +90,13 @@ const {
   @media (max-width: 480px) {
     .service-tech {
       padding: 3rem 0;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .service-tech__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/ServiceTechMarquee.astro
+++ b/src/components/sections/ServiceTechMarquee.astro
@@ -16,7 +16,7 @@ const {
 
 {technologies && technologies.length > 0 && (
   <section class="service-tech">
-    <div class="service-tech__container">
+    <div class="service-tech__container site-container">
       <div class="service-tech__header">
         <SectionLabel text="Tools & Technologies" />
         <h2 class="service-tech__title">
@@ -37,10 +37,6 @@ const {
   }
 
   .service-tech__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .service-tech__header {
@@ -93,10 +89,4 @@ const {
     }
   }
 
-  @media (min-width: 1024px) {
-    .service-tech__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>

--- a/src/components/sections/ServiceWork.astro
+++ b/src/components/sections/ServiceWork.astro
@@ -42,7 +42,7 @@ function getImageUrl(image: any): string | null {
 
 {projects && projects.length > 0 && (
   <section class="service-work">
-    <div class="service-work__container">
+    <div class="service-work__container site-container">
       <div class="service-work__header">
         <div>
           <SectionLabel text="Related Work" />
@@ -129,10 +129,6 @@ function getImageUrl(image: any): string | null {
   }
 
   .service-work__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .service-work__header {
@@ -326,13 +322,6 @@ function getImageUrl(image: any): string | null {
   }
 
   /* Responsive */
-  @media (min-width: 1024px) {
-    .service-work__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
-
   @media (max-width: 1024px) {
     .work-card--featured {
       grid-template-columns: 1fr;

--- a/src/components/sections/ServiceWork.astro
+++ b/src/components/sections/ServiceWork.astro
@@ -32,7 +32,8 @@ const rest = projects.slice(1, 3);
 function getImageUrl(image: any): string | null {
   if (!image) return null;
   try {
-    return urlFor(image).width(1200).format('webp').url();
+    // Pre-crop to 16:10 at Sanity CDN so Astro doesn't letterbox
+    return urlFor(image).width(1600).height(1000).fit('crop').format('webp').url();
   } catch {
     return null;
   }
@@ -69,6 +70,7 @@ function getImageUrl(image: any): string | null {
                   width={800}
                   height={500}
                   sizes="(max-width: 1024px) 100vw, 60vw"
+                  fill
                 />
               ) : (
                 <div class="work-card__placeholder">Featured Project</div>
@@ -98,9 +100,10 @@ function getImageUrl(image: any): string | null {
                 <SanityPicture
                   src={getImageUrl(project.thumbnailImage)!}
                   alt={project.title}
-                  width={600}
-                  height={400}
+                  width={800}
+                  height={500}
                   sizes="(max-width: 768px) 100vw, 50vw"
+                  fill
                 />
               ) : (
                 <div class="work-card__placeholder">Project Image</div>
@@ -127,7 +130,7 @@ function getImageUrl(image: any): string | null {
 
   .service-work__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -179,11 +182,19 @@ function getImageUrl(image: any): string | null {
   }
 
   .work-card--featured .work-card__image {
+    position: relative;
     aspect-ratio: 16/10;
     overflow: hidden;
   }
 
+  .work-card--featured .work-card__image :global(picture) {
+    position: absolute;
+    inset: 0;
+  }
+
   .work-card--featured .work-card__image :global(img) {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -238,11 +249,19 @@ function getImageUrl(image: any): string | null {
   }
 
   .work-card--small .work-card__image {
+    position: relative;
     aspect-ratio: 16/10;
     overflow: hidden;
   }
 
+  .work-card--small .work-card__image :global(picture) {
+    position: absolute;
+    inset: 0;
+  }
+
   .work-card--small .work-card__image :global(img) {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -307,6 +326,13 @@ function getImageUrl(image: any): string | null {
   }
 
   /* Responsive */
+  @media (min-width: 1024px) {
+    .service-work__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+  }
+
   @media (max-width: 1024px) {
     .work-card--featured {
       grid-template-columns: 1fr;

--- a/src/components/sections/StatsSection.astro
+++ b/src/components/sections/StatsSection.astro
@@ -73,7 +73,7 @@ const { stats, backgroundImage } = Astro.props;
   }
 
   .stats-section__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
     position: relative;
@@ -132,6 +132,11 @@ const { stats, backgroundImage } = Astro.props;
 
   /* Desktop: 4 columns in a row */
   @media (min-width: 1024px) {
+    .stats-section__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
     .stats-section__grid {
       grid-template-columns: repeat(4, 1fr);
       gap: 2rem;

--- a/src/components/sections/StatsSection.astro
+++ b/src/components/sections/StatsSection.astro
@@ -17,7 +17,7 @@ const { stats, backgroundImage } = Astro.props;
   class:list={["stats-section", { "stats-section--has-bg": !!backgroundImage }]}
   style={backgroundImage ? `background-image: url(${backgroundImage});` : undefined}
 >
-  <div class="stats-section__container">
+  <div class="stats-section__container site-container">
     <header class="stats-section__header">
       <SectionLabel text="By The Numbers" />
       <h2 class="stats-section__title"><HighlightedText text="Our *Impact*" /></h2>
@@ -73,9 +73,6 @@ const { stats, backgroundImage } = Astro.props;
   }
 
   .stats-section__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
     position: relative;
     z-index: 1;
   }
@@ -132,11 +129,6 @@ const { stats, backgroundImage } = Astro.props;
 
   /* Desktop: 4 columns in a row */
   @media (min-width: 1024px) {
-    .stats-section__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-
     .stats-section__grid {
       grid-template-columns: repeat(4, 1fr);
       gap: 2rem;

--- a/src/components/sections/Team.astro
+++ b/src/components/sections/Team.astro
@@ -59,7 +59,7 @@ function getInitials(name: string): string {
 ---
 
 <section class="team">
-  <div class="team__container">
+  <div class="team__container site-container">
     <header class="team__header">
       <SectionLabel text={label} variant="centered" />
       <h2 class="team__headline"><HighlightedText text={headline} /></h2>
@@ -112,12 +112,6 @@ function getInitials(name: string): string {
   .team {
     padding: 6rem 0;
     background: var(--bg-primary);
-  }
-
-  .team__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .team__header {
@@ -215,11 +209,6 @@ function getInitials(name: string): string {
 
   /* Desktop: 4 columns */
   @media (min-width: 1024px) {
-    .team__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-
     .team__grid {
       grid-template-columns: repeat(4, 1fr);
       gap: 2.5rem;

--- a/src/components/sections/Team.astro
+++ b/src/components/sections/Team.astro
@@ -115,7 +115,7 @@ function getInitials(name: string): string {
   }
 
   .team__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -215,6 +215,11 @@ function getInitials(name: string): string {
 
   /* Desktop: 4 columns */
   @media (min-width: 1024px) {
+    .team__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
     .team__grid {
       grid-template-columns: repeat(4, 1fr);
       gap: 2.5rem;

--- a/src/components/sections/Testimonials.astro
+++ b/src/components/sections/Testimonials.astro
@@ -50,7 +50,7 @@ function getAvatarUrl(photo: SanityImageSource | undefined, name: string | null 
 ---
 
 <section class="testimonials" aria-label="Client testimonials">
-  <div class="testimonials__container">
+  <div class="testimonials__container site-container">
     <header class="testimonials__header">
       <SectionLabel text="What Clients Say" />
       <h2 class="testimonials__title"><HighlightedText text="Client *Testimonials*" /></h2>
@@ -159,12 +159,6 @@ function getAvatarUrl(photo: SanityImageSource | undefined, name: string | null 
   .testimonials {
     padding: 6rem 0;
     background: var(--bg-primary);
-  }
-
-  .testimonials__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .testimonials__header {
@@ -424,10 +418,6 @@ function getAvatarUrl(photo: SanityImageSource | undefined, name: string | null 
       padding: 3rem 0;
     }
 
-    .testimonials__container {
-      padding: 0 1rem;
-    }
-
     .testimonial-card {
       padding: 1.5rem;
     }
@@ -461,12 +451,6 @@ function getAvatarUrl(photo: SanityImageSource | undefined, name: string | null 
     }
   }
 
-  @media (min-width: 1024px) {
-    .testimonials__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>
 
 <script>

--- a/src/components/sections/Testimonials.astro
+++ b/src/components/sections/Testimonials.astro
@@ -162,7 +162,7 @@ function getAvatarUrl(photo: SanityImageSource | undefined, name: string | null 
   }
 
   .testimonials__container {
-    max-width: 900px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -458,6 +458,13 @@ function getAvatarUrl(photo: SanityImageSource | undefined, name: string | null 
 
     .carousel__arrow {
       transition: none;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .testimonials__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/sections/Values.astro
+++ b/src/components/sections/Values.astro
@@ -39,7 +39,7 @@ const {
 ---
 
 <section class="values">
-  <div class="values__container">
+  <div class="values__container site-container">
     <header class="values__header">
       <SectionLabel text={label} variant="centered" />
       <h2 class="values__headline"><HighlightedText text={headline} /></h2>
@@ -73,12 +73,6 @@ const {
   .values {
     padding: 6rem 0;
     background: var(--bg-secondary);
-  }
-
-  .values__container {
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .values__header {
@@ -160,11 +154,6 @@ const {
 
   /* Desktop adjustments */
   @media (min-width: 1024px) {
-    .values__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-
     .values__grid {
       gap: 2rem;
     }

--- a/src/components/sections/Values.astro
+++ b/src/components/sections/Values.astro
@@ -76,7 +76,7 @@ const {
   }
 
   .values__container {
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -160,6 +160,11 @@ const {
 
   /* Desktop adjustments */
   @media (min-width: 1024px) {
+    .values__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
     .values__grid {
       gap: 2rem;
     }

--- a/src/components/sections/WorkGrid.astro
+++ b/src/components/sections/WorkGrid.astro
@@ -33,7 +33,7 @@ const filterServices = services.length > 0
 ---
 
 <section class="work-grid">
-  <div class="work-grid__container">
+  <div class="work-grid__container site-container">
     {/* Filter pills */}
     {filterServices.length > 0 && (
       <div class="work-grid__filters" role="tablist" aria-label="Filter projects by service">
@@ -124,10 +124,6 @@ const filterServices = services.length > 0
   }
 
   .work-grid__container {
-    width: 100%;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   /* ---- Filter pills ---- */
@@ -325,10 +321,6 @@ const filterServices = services.length > 0
       padding: 0 0 3rem;
     }
 
-    .work-grid__container {
-      padding: 0 1rem;
-    }
-
     .work-grid__filters {
       gap: 0.375rem;
     }
@@ -339,12 +331,6 @@ const filterServices = services.length > 0
     }
   }
 
-  @media (min-width: 1024px) {
-    .work-grid__container {
-      padding-left: 3rem;
-      padding-right: 3rem;
-    }
-  }
 </style>
 
 <script>

--- a/src/components/sections/WorkGrid.astro
+++ b/src/components/sections/WorkGrid.astro
@@ -54,7 +54,7 @@ const filterServices = services.length > 0
         let thumbUrl: string | undefined;
         if (study.thumbnailImage) {
           try {
-            thumbUrl = urlFor(study.thumbnailImage).width(800).height(600).format('webp').url();
+            thumbUrl = urlFor(study.thumbnailImage).width(1600).height(1000).fit('crop').format('webp').url();
           } catch { /* no image */ }
         }
         const serviceIds = (study.services || []).map((s) => s._id).join(',');
@@ -125,7 +125,7 @@ const filterServices = services.length > 0
 
   .work-grid__container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
     padding: 0 1.5rem;
   }
@@ -336,6 +336,13 @@ const filterServices = services.length > 0
     .work-grid__pill {
       padding: 6px 14px;
       font-size: 10px;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .work-grid__container {
+      padding-left: 3rem;
+      padding-right: 3rem;
     }
   }
 </style>

--- a/src/components/ui/SanityPicture.astro
+++ b/src/components/ui/SanityPicture.astro
@@ -39,6 +39,8 @@ interface Props {
   widths?: number[];
   /** Object fit style */
   fit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down';
+  /** Fill the parent container (absolute positioning) */
+  fill?: boolean;
 }
 
 const {
@@ -52,10 +54,15 @@ const {
   quality = 80,
   widths = [400, 800, 1200, 1600],
   fit = 'cover',
+  fill = false,
 } = Astro.props;
 
 // Filter widths to not exceed the base width
 const responsiveWidths = widths.filter(w => w <= width * 2);
+
+const imgStyle = fill
+  ? `position: absolute; inset: 0; width: 100%; height: 100%; object-fit: ${fit}; transition: transform 0.5s ease;`
+  : `object-fit: ${fit};`;
 ---
 
 <Picture
@@ -70,5 +77,5 @@ const responsiveWidths = widths.filter(w => w <= width * 2);
   quality={quality}
   loading={loading}
   class={className}
-  style={`object-fit: ${fit};`}
+  style={imgStyle}
 />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -11,7 +11,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="decorative-line line-left" aria-hidden="true"></div>
     <div class="decorative-line line-right" aria-hidden="true"></div>
 
-    <div class="error-page__content">
+    <div class="error-page__content site-container">
       <!-- Large Background 404 -->
       <span class="error-page__404" aria-hidden="true">404</span>
 
@@ -73,7 +73,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   .error-page__content {
     position: relative;
-    max-width: 600px;
   }
 
   /* Large background 404 */

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -54,7 +54,7 @@ const jobPostingSchema = hasJobs
 
   <!-- Open Positions or Empty State -->
   <section class="careers-listings">
-    <div class="careers-listings__container">
+    <div class="careers-listings__container site-container">
       {hasJobs ? (
         <>
           <SectionLabel text="Open Positions" />
@@ -93,7 +93,7 @@ const jobPostingSchema = hasJobs
 
   <!-- Application Form -->
   <section class="careers-form" id="apply">
-    <div class="careers-form__container">
+    <div class="careers-form__container site-container">
       <SectionLabel text="Apply" />
       <h2 class="careers-form__title">
         <HighlightedText text="Send Us Your *Details*" />
@@ -191,9 +191,6 @@ const jobPostingSchema = hasJobs
   }
 
   .careers-listings__container {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .careers-listings__list {
@@ -330,9 +327,6 @@ const jobPostingSchema = hasJobs
   }
 
   .careers-form__container {
-    max-width: 700px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .careers-form__title {

--- a/src/pages/industries/index.astro
+++ b/src/pages/industries/index.astro
@@ -67,7 +67,7 @@ const seoDescription = 'Deep domain expertise across sectors that power the mode
   </PageHero>
 
   <section class="industries-stacked">
-    <div class="industries-stacked__container">
+    <div class="industries-stacked__container site-container">
       <header class="industries-stacked__header">
         <SectionLabel text="Our Expertise" />
         <h2 class="industries-stacked__title">
@@ -138,9 +138,6 @@ const seoDescription = 'Deep domain expertise across sectors that power the mode
   }
 
   .industries-stacked__container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   /* ─── Header ─── */

--- a/src/pages/insights/[...page].astro
+++ b/src/pages/insights/[...page].astro
@@ -69,7 +69,7 @@ const seoDescription =
   </PageHero>
 
   <section class="insights-list">
-    <div class="insights-list__container">
+    <div class="insights-list__container site-container">
 
       <!-- Category filter pills — nav links to category pages -->
       {categories && categories.length > 0 && (
@@ -200,10 +200,6 @@ const seoDescription =
   }
 
   .insights-list__container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   /* ---- Filter pills ---- */
@@ -467,10 +463,6 @@ const seoDescription =
   @media (max-width: 480px) {
     .insights-list {
       padding: 0 0 3rem;
-    }
-
-    .insights-list__container {
-      padding: 0 1rem;
     }
 
     .insights-list__filters {

--- a/src/pages/insights/category/[slug].astro
+++ b/src/pages/insights/category/[slug].astro
@@ -70,7 +70,7 @@ const seoDescription = category.description || `Expert insights and articles abo
   </PageHero>
 
   <section class="insights-list">
-    <div class="insights-list__container">
+    <div class="insights-list__container site-container">
       <!-- Category filter pills -->
       {allCategories && allCategories.length > 0 && (
         <div class="insights-list__filters" role="tablist" aria-label="Filter articles by category">
@@ -171,10 +171,6 @@ const seoDescription = category.description || `Expert insights and articles abo
   }
 
   .insights-list__container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   /* ---- Filter pills ---- */
@@ -377,10 +373,6 @@ const seoDescription = category.description || `Expert insights and articles abo
   @media (max-width: 480px) {
     .insights-list {
       padding: 0 0 3rem;
-    }
-
-    .insights-list__container {
-      padding: 0 1rem;
     }
 
     .insights-list__filters {

--- a/src/pages/privacy-policy/index.astro
+++ b/src/pages/privacy-policy/index.astro
@@ -13,7 +13,7 @@ import PageHero from '../../components/sections/PageHero.astro';
   </PageHero>
 
   <section class="legal-content">
-    <div class="legal-content__container">
+    <div class="legal-content__container site-container">
 
       <h3>1. Information We Collect</h3>
       <p>We collect information you provide directly to us, including your name, email address, phone number, and any other information you choose to provide when you fill out a contact form, apply for a position, or communicate with us.</p>
@@ -71,9 +71,6 @@ import PageHero from '../../components/sections/PageHero.astro';
   }
 
   .legal-content__container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .legal-content__container h3 {

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -65,7 +65,7 @@ const servicesWithImages = services.map((service) => {
 
   <!-- Services Accordion -->
   <section class="services-accordion">
-    <div class="services-accordion__container">
+    <div class="services-accordion__container site-container">
       {servicesWithImages.map((service, index) => (
         <div class="accordion-item" data-accordion-item>
           {/* Full-bleed background image (atmospheric) */}
@@ -169,10 +169,6 @@ const servicesWithImages = services.map((service) => {
   }
 
   .services-accordion__container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   /* ============================================
@@ -492,10 +488,6 @@ const servicesWithImages = services.map((service) => {
   @media (max-width: 480px) {
     .services-accordion {
       padding: 0 0 3rem;
-    }
-
-    .services-accordion__container {
-      padding: 0 1rem;
     }
 
     .accordion-item__header {

--- a/src/pages/terms-of-service/index.astro
+++ b/src/pages/terms-of-service/index.astro
@@ -13,7 +13,7 @@ import PageHero from '../../components/sections/PageHero.astro';
   </PageHero>
 
   <section class="legal-content">
-    <div class="legal-content__container">
+    <div class="legal-content__container site-container">
 
       <h3>1. Acceptance of Terms</h3>
       <p>By accessing and using the KP Infotech website (kpinfo.tech), you accept and agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use our website.</p>
@@ -59,9 +59,6 @@ import PageHero from '../../components/sections/PageHero.astro';
   }
 
   .legal-content__container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 0 1.5rem;
   }
 
   .legal-content__container h3 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -93,6 +93,22 @@ img {
   height: auto;
 }
 
+/* Site container — matches header's 1440px bounding box */
+.site-container {
+  max-width: 1440px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .site-container {
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+}
+
 /* Section Label Pattern - base class only, styles are inline in component */
 .section-label {
   /* Styles moved to inline in SectionLabel.astro to avoid CSS code-splitting */


### PR DESCRIPTION
## Summary
- Align all section containers site-wide to the header's 1440px bounding box with consistent 3rem desktop padding
- Increase footer logo size (40px → 80px) and align footer container
- Fix hero left-edge misalignment (removed 1280px+ padding override)
- Add `fill` prop to `SanityPicture` for absolute-positioned image filling in card containers
- Pre-crop work thumbnails at Sanity CDN (16:10 via `fit=crop`) to prevent Astro/Sharp letterboxing
- Make Testimonials and CTA sections full-width within the 1440px container
- Introduce `.site-container` global utility class and refactor all 34 section/page containers to use it, removing ~310 lines of duplicated CSS

## Test plan
- [ ] Verify homepage sections align with header at 1440px viewport
- [ ] Check hero text left edge aligns with section headings below
- [ ] Confirm work card images fill containers with no gaps/bars
- [ ] Test responsive behavior at mobile/tablet/desktop breakpoints
- [ ] Spot-check service, industry, work, insights, about, contact, careers, and legal pages for alignment
- [ ] Verify footer logo is larger and footer container aligns with header

🤖 Generated with [Claude Code](https://claude.com/claude-code)