### PR TITLE
[codex] Add SEO GEO technical fixes

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -131,6 +131,7 @@
 /casestudy/*   /work/:splat  301
 
 # ─── Legacy hire pages → services ────────────────────────────────────────────
+/career/                    /careers/                    301
 /hire-wordpress-developer/   /services/web-development/   301
 /hire-laravel-developer/     /services/web-development/   301
 /hire-react-js-developer/    /services/web-development/   301

--- a/sanity/schemas/objects/richText.tsx
+++ b/sanity/schemas/objects/richText.tsx
@@ -1,4 +1,4 @@
-import { defineType } from 'sanity';
+import { defineField, defineType } from 'sanity';
 import { HighlightIcon } from '@sanity/icons';
 import React from 'react';
 
@@ -22,6 +22,46 @@ export const richText = defineType({
         icon: HighlightIcon,
         component: HighlightDecorator,
       },
+    ],
+    annotations: [
+      defineField({
+        name: 'externalLink',
+        title: 'External Link',
+        type: 'object',
+        fields: [
+          defineField({
+            name: 'href',
+            title: 'URL',
+            type: 'url',
+            validation: (Rule) => Rule.required(),
+          }),
+          defineField({
+            name: 'openInNewTab',
+            title: 'Open in new tab',
+            type: 'boolean',
+            initialValue: true,
+          }),
+        ],
+      }),
+      defineField({
+        name: 'internalLink',
+        title: 'Internal Link',
+        type: 'object',
+        fields: [
+          defineField({
+            name: 'reference',
+            title: 'Page',
+            type: 'reference',
+            to: [
+              { type: 'service' },
+              { type: 'industry' },
+              { type: 'caseStudy' },
+              { type: 'blogPost' },
+            ],
+            validation: (Rule) => Rule.required(),
+          }),
+        ],
+      }),
     ],
   },
 });

--- a/src/components/sections/BlogPostContent.astro
+++ b/src/components/sections/BlogPostContent.astro
@@ -3,6 +3,7 @@ import { PortableText } from 'astro-portabletext';
 import PortableTextImage from '../ui/PortableTextImage.astro';
 import PortableTextHighlight from '../ui/PortableTextHighlight.astro';
 import PortableTextCode from '../ui/PortableTextCode.astro';
+import PortableTextLink from '../ui/PortableTextLink.astro';
 
 interface Props {
   content?: any[];
@@ -17,6 +18,8 @@ const components = {
   },
   mark: {
     highlight: PortableTextHighlight,
+    externalLink: PortableTextLink,
+    internalLink: PortableTextLink,
   },
 };
 

--- a/src/components/sections/CaseStudyContent.astro
+++ b/src/components/sections/CaseStudyContent.astro
@@ -3,6 +3,7 @@ import { PortableText } from 'astro-portabletext';
 import PortableTextImage from '../ui/PortableTextImage.astro';
 import PortableTextHighlight from '../ui/PortableTextHighlight.astro';
 import PortableTextCode from '../ui/PortableTextCode.astro';
+import PortableTextLink from '../ui/PortableTextLink.astro';
 
 interface Props {
   content?: any[];
@@ -17,6 +18,8 @@ const components = {
   },
   mark: {
     highlight: PortableTextHighlight,
+    externalLink: PortableTextLink,
+    internalLink: PortableTextLink,
   },
 };
 

--- a/src/components/sections/ProjectOverview.astro
+++ b/src/components/sections/ProjectOverview.astro
@@ -2,6 +2,7 @@
 import { PortableText } from 'astro-portabletext';
 import SectionLabel from '../ui/SectionLabel.astro';
 import PortableTextHighlight from '../ui/PortableTextHighlight.astro';
+import PortableTextLink from '../ui/PortableTextLink.astro';
 
 interface Props {
   challenge?: any[];
@@ -14,6 +15,8 @@ const { challenge, approach, resultsSummary } = Astro.props;
 const components = {
   mark: {
     highlight: PortableTextHighlight,
+    externalLink: PortableTextLink,
+    internalLink: PortableTextLink,
   },
 };
 

--- a/src/components/sections/ServiceContent.astro
+++ b/src/components/sections/ServiceContent.astro
@@ -3,6 +3,7 @@ import SectionLabel from '../ui/SectionLabel.astro';
 import HighlightedText from '../ui/HighlightedText.astro';
 import PortableTextImage from '../ui/PortableTextImage.astro';
 import PortableTextHighlight from '../ui/PortableTextHighlight.astro';
+import PortableTextLink from '../ui/PortableTextLink.astro';
 import { PortableText } from 'astro-portabletext';
 
 interface Props {
@@ -21,6 +22,8 @@ const components = {
   },
   mark: {
     highlight: PortableTextHighlight,
+    externalLink: PortableTextLink,
+    internalLink: PortableTextLink,
   },
 };
 ---

--- a/src/components/ui/PortableTextLink.astro
+++ b/src/components/ui/PortableTextLink.astro
@@ -1,0 +1,37 @@
+---
+const { node, value, markDef } = Astro.props;
+
+const annotation = node?.value || node?.markDef || value || markDef || node || {};
+const reference = annotation.reference;
+const slug = reference?.slug?.current;
+
+const internalTypeToPath: Record<string, string> = {
+  service: 'services',
+  industry: 'industries',
+  caseStudy: 'work',
+  blogPost: 'insights',
+};
+
+let href: string | undefined = annotation.href;
+let target: string | undefined;
+let rel: string | undefined;
+
+if (!href && reference?._type && slug && internalTypeToPath[reference._type]) {
+  href = `/${internalTypeToPath[reference._type]}/${slug}/`;
+}
+
+if (annotation.openInNewTab) {
+  target = '_blank';
+  rel = 'noopener noreferrer';
+}
+---
+
+{href ? (
+  <a href={href} target={target} rel={rel}>
+    <slot />
+  </a>
+) : (
+  <span>
+    <slot />
+  </span>
+)}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,8 @@ import Navigation from '../components/Navigation.astro';
 import Footer from '../components/Footer.astro';
 import { client } from '../lib/sanity';
 import { siteSettingsQuery } from '../lib/queries';
+import defaultOgFallback from '../assets/hero-placeholder.jpg';
+import { canonicalUrl, jsonLdGraph, organizationSchema, seoImageUrl } from '../lib/seo';
 import CustomCursor from '../components/effects/CustomCursor.astro';
 import ScrollProgress from '../components/effects/ScrollProgress.astro';
 import WhatsAppButton from '../components/ui/WhatsAppButton.astro';
@@ -12,22 +14,34 @@ import WhatsAppButton from '../components/ui/WhatsAppButton.astro';
 interface Props {
   title?: string;
   description?: string;
-  ogImage?: string;
+  ogImage?: string | Record<string, any>;
+  ogType?: 'website' | 'article';
   canonicalURL?: string;
+  jsonLd?: Record<string, any> | Array<Record<string, any> | undefined | null>;
 }
 
 // Fetch site settings from Sanity
 const siteSettings = await client.fetch(siteSettingsQuery);
 
 const {
-  title = siteSettings?.siteName || 'KP Infotech',
-  description = siteSettings?.defaultSeoDescription || 'Premium Design and Technology studio crafting digital experiences that elevate brands and drive measurable business growth.',
-  ogImage = '/og-image.jpg',
-  canonicalURL = Astro.url.href,
+  title,
+  description,
+  ogImage,
+  ogType = 'website',
+  canonicalURL,
+  jsonLd,
 } = Astro.props;
 
 const siteName = siteSettings?.siteName || 'KP Infotech';
-const fullTitle = title === siteName ? title : `${title} — ${siteName}`;
+const pageTitle = title || siteSettings?.defaultSeoTitle || siteName;
+const fullTitle = pageTitle === siteName || pageTitle.includes(siteName)
+  ? pageTitle
+  : `${pageTitle} — ${siteName}`;
+const metaDescription = description || siteSettings?.defaultSeoDescription || 'Premium Design and Technology studio crafting digital experiences that elevate brands and drive measurable business growth.';
+const canonical = canonicalUrl(canonicalURL || Astro.url.href);
+const resolvedOgImage = seoImageUrl(ogImage, siteSettings?.defaultOgImage, defaultOgFallback.src);
+const jsonLdNodes = Array.isArray(jsonLd) ? jsonLd : [jsonLd];
+const jsonLdPayload = jsonLdGraph([organizationSchema(siteSettings), ...jsonLdNodes]);
 ---
 
 <!doctype html>
@@ -43,24 +57,25 @@ const fullTitle = title === siteName ? title : `${title} — ${siteName}`;
     <!-- Primary Meta Tags -->
     <title>{fullTitle}</title>
     <meta name="title" content={fullTitle} />
-    <meta name="description" content={description} />
+    <meta name="description" content={metaDescription} />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href={canonicalURL} />
+    <link rel="canonical" href={canonical} />
 
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={canonical} />
     <meta property="og:title" content={fullTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content={ogImage} />
+    <meta property="og:description" content={metaDescription} />
+    {resolvedOgImage && <meta property="og:image" content={resolvedOgImage} />}
+    <meta property="og:site_name" content={siteName} />
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content={canonicalURL} />
-    <meta property="twitter:title" content={fullTitle} />
-    <meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content={ogImage} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content={canonical} />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={metaDescription} />
+    {resolvedOgImage && <meta name="twitter:image" content={resolvedOgImage} />}
 
     <!-- Theme Color -->
     <meta name="theme-color" content="#0a0a0a" />
@@ -73,6 +88,10 @@ const fullTitle = title === siteName ? title : `${title} — ${siteName}`;
 
     <!-- View Transitions -->
     <ClientRouter />
+
+    {jsonLdPayload && (
+      <script type="application/ld+json" set:html={JSON.stringify(jsonLdPayload)} />
+    )}
 
     <!-- Additional head content via slot -->
     <slot name="head" />

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -17,7 +17,8 @@ export const siteSettingsQuery = `
     stats,
     footerText,
     defaultSeoTitle,
-    defaultSeoDescription
+    defaultSeoDescription,
+    defaultOgImage
   }
 `;
 
@@ -41,6 +42,14 @@ export const homepageDataQuery = `
     siteName,
     siteTagline,
     heroHeadline,
+    logo,
+    contactEmail,
+    contactPhone,
+    address,
+    socialLinks,
+    defaultSeoTitle,
+    defaultSeoDescription,
+    defaultOgImage,
     techStack,
     stats
   },
@@ -100,6 +109,7 @@ export const allServicesQuery = `
 export const serviceBySlugQuery = `
   *[_type == "service" && slug.current == $slug][0] {
     _id,
+    _updatedAt,
     title,
     slug,
     tagline,
@@ -108,7 +118,20 @@ export const serviceBySlugQuery = `
     "iconCustom": coalesce(iconCustom, icon),
     heroImage,
     contentHeading,
-    content,
+    content[]{
+      ...,
+      markDefs[]{
+        ...,
+        _type == "internalLink" => {
+          ...,
+          reference->{
+            _type,
+            title,
+            slug
+          }
+        }
+      }
+    },
     processHeading,
     process,
     techHeading,
@@ -241,6 +264,8 @@ export const featuredCaseStudiesQuery = `
 export const caseStudyBySlugQuery = `
   *[_type == "caseStudy" && slug.current == $slug][0] {
     _id,
+    _createdAt,
+    _updatedAt,
     title,
     slug,
     client,
@@ -258,10 +283,49 @@ export const caseStudyBySlugQuery = `
       title,
       slug
     },
-    challenge,
-    approach,
+    challenge[]{
+      ...,
+      markDefs[]{
+        ...,
+        _type == "internalLink" => {
+          ...,
+          reference->{
+            _type,
+            title,
+            slug
+          }
+        }
+      }
+    },
+    approach[]{
+      ...,
+      markDefs[]{
+        ...,
+        _type == "internalLink" => {
+          ...,
+          reference->{
+            _type,
+            title,
+            slug
+          }
+        }
+      }
+    },
     resultsSummary,
-    content,
+    content[]{
+      ...,
+      markDefs[]{
+        ...,
+        _type == "internalLink" => {
+          ...,
+          reference->{
+            _type,
+            title,
+            slug
+          }
+        }
+      }
+    },
     results,
     testimonial->{
       _id,
@@ -330,13 +394,28 @@ export const featuredBlogPostsQuery = `
 export const blogPostBySlugQuery = `
   *[_type == "blogPost" && slug.current == $slug][0] {
     _id,
+    _createdAt,
+    _updatedAt,
     title,
     slug,
     excerpt,
     featuredImage,
     publishedAt,
     readTime,
-    content,
+    content[]{
+      ...,
+      markDefs[]{
+        ...,
+        _type == "internalLink" => {
+          ...,
+          reference->{
+            _type,
+            title,
+            slug
+          }
+        }
+      }
+    },
     category->{
       _id,
       title,

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,160 @@
+import type { SanityImageSource } from '@sanity/image-url/lib/types/types';
+import { getOriginalAssetUrl, isSvgAsset, urlFor } from './sanity';
+
+export const SITE_URL = 'https://kpinfo.tech';
+const SITE_ORIGIN = new URL(SITE_URL).origin;
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue | undefined };
+
+export type JsonLdNode = Record<string, JsonValue | undefined>;
+
+export type BreadcrumbItem = {
+  name: string;
+  path: string;
+};
+
+export function absoluteUrl(input?: string | URL | null): string {
+  if (!input) return SITE_URL;
+
+  const raw = input instanceof URL ? input.href : input;
+  return new URL(raw, SITE_ORIGIN).href;
+}
+
+export function canonicalUrl(input?: string | URL | null): string {
+  const url = new URL(input ? String(input) : SITE_URL, SITE_ORIGIN);
+  url.protocol = 'https:';
+  url.host = new URL(SITE_URL).host;
+  url.search = '';
+  url.hash = '';
+
+  const lastSegment = url.pathname.split('/').filter(Boolean).at(-1);
+  const hasFileExtension = !!lastSegment && /\.[a-z0-9]+$/i.test(lastSegment);
+  if (!hasFileExtension && !url.pathname.endsWith('/')) {
+    url.pathname = `${url.pathname}/`;
+  }
+
+  return url.href;
+}
+
+export function sanityImageUrl(source?: SanityImageSource | null, width = 1200, height = 630): string | undefined {
+  if (!source) return undefined;
+
+  try {
+    if (isSvgAsset(source)) {
+      return getOriginalAssetUrl(source) || undefined;
+    }
+
+    return urlFor(source).width(width).height(height).fit('crop').format('jpg').url();
+  } catch {
+    return undefined;
+  }
+}
+
+export function seoImageUrl(
+  pageImage?: string | SanityImageSource | null,
+  defaultImage?: SanityImageSource | null,
+  fallbackImage?: string | null
+): string | undefined {
+  if (typeof pageImage === 'string' && pageImage.trim()) {
+    return absoluteUrl(pageImage);
+  }
+
+  const pageSanityImage = pageImage ? sanityImageUrl(pageImage as SanityImageSource) : undefined;
+  const defaultSanityImage = sanityImageUrl(defaultImage);
+  const fallback = fallbackImage ? absoluteUrl(fallbackImage) : undefined;
+
+  return pageSanityImage || defaultSanityImage || fallback;
+}
+
+export function removeEmpty<T extends JsonValue | undefined>(value: T): T | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => removeEmpty(item))
+      .filter((item): item is JsonValue => item !== undefined);
+
+    return (items.length > 0 ? items : undefined) as T | undefined;
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value)
+      .map(([key, item]) => [key, removeEmpty(item as JsonValue)] as const)
+      .filter(([, item]) => item !== undefined);
+
+    return (entries.length > 0 ? Object.fromEntries(entries) : undefined) as T | undefined;
+  }
+
+  return value;
+}
+
+export function jsonLdGraph(nodes: Array<JsonLdNode | undefined | null>): JsonLdNode | undefined {
+  const graph = nodes
+    .map((node) => removeEmpty(node as JsonValue) as JsonLdNode | undefined)
+    .filter((node): node is JsonLdNode => !!node);
+
+  if (graph.length === 0) return undefined;
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': graph,
+  };
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]): JsonLdNode | undefined {
+  if (items.length === 0) return undefined;
+
+  return {
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: canonicalUrl(item.path),
+    })),
+  };
+}
+
+export function organizationSchema(settings?: any): JsonLdNode {
+  const socialLinks = settings?.socialLinks
+    ? Object.values(settings.socialLinks).filter((url): url is string => typeof url === 'string' && url.length > 0)
+    : [];
+
+  return {
+    '@type': 'Organization',
+    '@id': `${SITE_URL}/#organization`,
+    name: settings?.siteName || 'KP Infotech',
+    url: SITE_URL,
+    logo: sanityImageUrl(settings?.logo, 512, 512),
+    email: settings?.contactEmail,
+    telephone: settings?.contactPhone,
+    address: settings?.address
+      ? {
+          '@type': 'PostalAddress',
+          streetAddress: settings.address,
+          addressCountry: 'IN',
+        }
+      : undefined,
+    sameAs: socialLinks,
+  };
+}
+
+export function websiteSchema(settings?: any): JsonLdNode {
+  return {
+    '@type': 'WebSite',
+    '@id': `${SITE_URL}/#website`,
+    name: settings?.siteName || 'KP Infotech',
+    url: SITE_URL,
+    publisher: { '@id': `${SITE_URL}/#organization` },
+  };
+}
+
+export function pageId(path: string): string {
+  return `${canonicalUrl(path)}#webpage`;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import StatsSection from '../components/sections/StatsSection.astro';
 import IndustriesBento from '../components/sections/IndustriesBento.astro';
 import Testimonials from '../components/sections/Testimonials.astro';
 import CTASection from '../components/sections/CTASection.astro';
+import { websiteSchema } from '../lib/seo';
 
 // Fetch all homepage data from Sanity
 const data = await client.fetch(homepageDataQuery);
@@ -60,11 +61,16 @@ const stats = siteSettings?.stats?.map((stat: any) => ({
 
 // Default description for hero
 const heroDescription = "We craft premium digital experiences for startups and businesses. UI/UX design, web development, mobile apps, and ERP solutions from Ahmedabad to the world.";
+const homeJsonLd = [
+  websiteSchema(siteSettings),
+];
 ---
 
 <BaseLayout
   title="KP Infotech"
   description={heroDescription}
+  ogImage={homeHeroUrl}
+  jsonLd={homeJsonLd}
 >
   <!-- Hero Section -->
   <Hero

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -7,6 +7,7 @@ import RelatedPosts from '../../components/sections/RelatedPosts.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { allBlogPostsQuery, blogPostBySlugQuery } from '../../lib/queries';
+import { breadcrumbSchema, canonicalUrl } from '../../lib/seo';
 
 export async function getStaticPaths() {
   const posts = await client.fetch<Array<{ slug: { current: string } }>>(
@@ -59,9 +60,49 @@ const authorData = post.author ? {
 
 const seoTitle = post.seoTitle || `${post.title}`;
 const seoDescription = post.seoDescription || post.excerpt;
+const postUrl = canonicalUrl(`/insights/${slug}/`);
+const blogJsonLd = [
+  breadcrumbSchema([
+    { name: 'Home', path: '/' },
+    { name: 'Insights', path: '/insights/' },
+    ...(post.category?.title && post.category?.slug?.current
+      ? [{ name: post.category.title, path: `/insights/category/${post.category.slug.current}/` }]
+      : []),
+    { name: post.title, path: `/insights/${slug}/` },
+  ]),
+  {
+    '@type': 'BlogPosting',
+    '@id': `${postUrl}#article`,
+    headline: post.title,
+    description: seoDescription,
+    image: heroImageUrl,
+    url: postUrl,
+    datePublished: post.publishedAt,
+    dateModified: post._updatedAt || post.publishedAt,
+    author: post.author ? {
+      '@type': 'Person',
+      name: post.author.name,
+      jobTitle: post.author.role,
+      sameAs: [post.author.linkedin, post.author.twitter].filter(Boolean),
+    } : {
+      '@type': 'Organization',
+      '@id': 'https://kpinfo.tech/#organization',
+      name: 'KP Infotech',
+    },
+    publisher: { '@id': 'https://kpinfo.tech/#organization' },
+    articleSection: post.category?.title,
+    keywords: post.tags,
+  },
+];
 ---
 
-<BaseLayout title={seoTitle} description={seoDescription}>
+<BaseLayout
+  title={seoTitle}
+  description={seoDescription}
+  ogImage={heroImageUrl}
+  ogType="article"
+  jsonLd={blogJsonLd}
+>
   <BlogPostHero post={heroPost} />
 
   {post.content && post.content.length > 0 && (

--- a/src/pages/services/[slug].astro
+++ b/src/pages/services/[slug].astro
@@ -9,6 +9,7 @@ import ServiceFAQ from '../../components/sections/ServiceFAQ.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { allServicesQuery, serviceBySlugQuery } from '../../lib/queries';
+import { breadcrumbSchema, canonicalUrl } from '../../lib/seo';
 
 export async function getStaticPaths() {
   const services = await client.fetch<Array<{ slug: { current: string } }>>(allServicesQuery);
@@ -38,11 +39,46 @@ if (service.heroImage) {
 
 const seoTitle = service.seoTitle || service.title;
 const seoDescription = service.seoDescription || service.excerpt || service.tagline;
+const serviceUrl = canonicalUrl(`/services/${slug}/`);
+const serviceJsonLd = [
+  breadcrumbSchema([
+    { name: 'Home', path: '/' },
+    { name: 'Services', path: '/services/' },
+    { name: service.title, path: `/services/${slug}/` },
+  ]),
+  {
+    '@type': 'Service',
+    '@id': `${serviceUrl}#service`,
+    name: service.title,
+    description: seoDescription,
+    url: serviceUrl,
+    provider: { '@id': 'https://kpinfo.tech/#organization' },
+    serviceType: service.title,
+    areaServed: {
+      '@type': 'Country',
+      name: 'India',
+    },
+  },
+  service.faqs && service.faqs.length > 0 ? {
+    '@type': 'FAQPage',
+    '@id': `${serviceUrl}#faq`,
+    mainEntity: service.faqs.map((faq: any) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  } : undefined,
+];
 ---
 
 <BaseLayout
   title={seoTitle}
   description={seoDescription}
+  ogImage={heroImageUrl}
+  jsonLd={serviceJsonLd}
 >
   <ServiceHero
     title={service.title}

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -9,6 +9,7 @@ import NextProject from '../../components/sections/NextProject.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { allCaseStudiesQuery, caseStudyBySlugQuery } from '../../lib/queries';
+import { breadcrumbSchema, canonicalUrl } from '../../lib/seo';
 
 export async function getStaticPaths() {
   const caseStudies = await client.fetch<Array<{ slug: { current: string } }>>(allCaseStudiesQuery);
@@ -38,11 +39,42 @@ if (study.heroImage) {
 
 const seoTitle = study.seoTitle || study.title;
 const seoDescription = study.seoDescription || study.excerpt;
+const studyUrl = canonicalUrl(`/work/${slug}/`);
+const caseStudyJsonLd = [
+  breadcrumbSchema([
+    { name: 'Home', path: '/' },
+    { name: 'Work', path: '/work/' },
+    { name: study.title, path: `/work/${slug}/` },
+  ]),
+  {
+    '@type': 'CreativeWork',
+    '@id': `${studyUrl}#creative-work`,
+    name: study.title,
+    headline: study.title,
+    description: seoDescription,
+    image: heroImageUrl,
+    url: studyUrl,
+    dateCreated: study._createdAt,
+    dateModified: study._updatedAt,
+    creator: { '@id': 'https://kpinfo.tech/#organization' },
+    publisher: { '@id': 'https://kpinfo.tech/#organization' },
+    about: [
+      ...(study.services || []).map((service: any) => service?.title).filter(Boolean),
+      ...(study.industries || []).map((industry: any) => industry?.title).filter(Boolean),
+    ],
+    client: study.client ? {
+      '@type': 'Organization',
+      name: study.client,
+    } : undefined,
+  },
+];
 ---
 
 <BaseLayout
   title={seoTitle}
   description={seoDescription}
+  ogImage={heroImageUrl}
+  jsonLd={caseStudyJsonLd}
 >
   <CaseStudyHero
     title={study.title}


### PR DESCRIPTION
## Summary
- add centralized SEO helpers for canonical URLs, absolute OG images, image fallbacks, and JSON-LD graph output
- wire Organization, WebSite, BreadcrumbList, Service, FAQPage, BlogPosting, and CreativeWork schema across key pages
- add Sanity rich text link annotations/rendering and the missing /career/ redirect

## Validation
- PUBLIC_SANITY_PROJECT_ID=5rux0mv2 PUBLIC_SANITY_DATASET=production npm run build

## Notes
- Build passes with existing Astro route-conflict warnings for /insights/category/design and /insights/uniting-website-design-and-digital-marketing.
- AGENTS.md remains untracked locally and is not included in this PR.