### PR TITLE
[codex] Add Worker-level migration redirects

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,18 @@
+import { handle } from '@astrojs/cloudflare/handler';
+
+import {
+  getMigrationRedirectLocation,
+  PERMANENT_REDIRECT_STATUS,
+} from './worker/migration-redirects.js';
+
+export default {
+  fetch(request, env, context) {
+    const redirectLocation = getMigrationRedirectLocation(request.url);
+
+    if (redirectLocation) {
+      return Response.redirect(redirectLocation, PERMANENT_REDIRECT_STATUS);
+    }
+
+    return handle(request, env, context);
+  },
+};

--- a/src/worker/migration-redirects.js
+++ b/src/worker/migration-redirects.js
@@ -1,0 +1,228 @@
+export const PERMANENT_REDIRECT_STATUS = 301;
+
+const EXACT_REDIRECTS = new Map([
+  ['/services/web-application-development', '/services/custom-software-development/'],
+  ['/services/erp-solutions', '/services/erp-software/'],
+  ['/services/ai-automation', '/services/ai-automation-agents/'],
+  ['/services/mobile-app-development', '/services/custom-software-development/'],
+  ['/services/ui-ux-design', '/services/custom-software-development/'],
+  ['/services/website-design', '/services/custom-software-development/'],
+  ['/services/graphics-design', '/services/custom-software-development/'],
+  ['/services/mobile-web-app', '/services/custom-software-development/'],
+  ['/services/erp-software/odoo-crm', '/services/erp-software/'],
+  ['/erp-software', '/services/erp-software/'],
+  ['/odoo-crm', '/services/erp-software/'],
+  ['/mobile-web-app', '/services/custom-software-development/'],
+  ['/career', '/careers/'],
+  ['/blogs', '/insights/'],
+  ['/casestudy', '/work/'],
+  ['/hire-wordpress-developer', '/services/custom-software-development/'],
+  ['/hire-laravel-developer', '/services/custom-software-development/'],
+  ['/hire-react-js-developer', '/services/custom-software-development/'],
+  ['/kp-infotech-faqs', '/contact/'],
+]);
+
+const MIGRATED_BLOG_SLUGS = new Set([
+  '15-proven-benefits-of-erp-systems-for-businesses-in-2025',
+  '5-best-modern-website-design-ideas',
+  'about-kp-infotech-expertise',
+  'affordable-web-hosting-solutions-for-businesses',
+  'analytics-and-data-visualization',
+  'analytics-in-banking-industry',
+  'angular-vs-react',
+  'angularjs-vs-reactjs',
+  'application-cloud-migration',
+  'application-modernization-strategy',
+  'applications-based-on-cloud-computing',
+  'architecture-of-a-mobile-app',
+  'b-2-b-lead-generation-strategies',
+  'benefits-of-custom-software-development',
+  'benefits-of-erp',
+  'best-ecommerce-platform-for-small-business',
+  'best-framework-for-web-application',
+  'best-hr-software-for-startups',
+  'best-mobile-app-development-company',
+  'best-practices-for-devops',
+  'best-seo-tools-for-small-businesses',
+  'best-web-application-frameworks',
+  'brand-style-guide-template',
+  'business-process-automation-tools',
+  'business-process-improvement-methods',
+  'cloud-application-architecture-diagram',
+  'cloud-deployment-models-diagram',
+  'cloud-migration-checklist',
+  'cloud-migration-plan',
+  'cloud-migration-solution',
+  'create-online-presence',
+  'custom-software-development-costs',
+  'data-visualization-best-practices',
+  'database-design-best-practices',
+  'database-security-best-practices',
+  'designing-a-web-application',
+  'digital-marketing-for-manufacturers',
+  'digital-marketing-for-startups',
+  'digital-marketing-tips-for-small-businesses',
+  'digital-transformation-roadmap',
+  'ecommerce-website-development-cost',
+  'ecommerce-website-development-services',
+  'erp-for-retail-stores',
+  'erp-implementation-best-practices',
+  'erp-implementation-cost',
+  'erp-implementation-issues',
+  'erp-software-odoo',
+  'erp-solutions-for-small-businesses',
+  'erp-system-selection-criteria',
+  'freelancer-vs-graphic-design-company-for-your-startup-which-should-you-choose',
+  'functional-vs-unit-tests',
+  'global-technology-solutions',
+  'google-analytics-360',
+  'graphic-design-tips',
+  'hire-a-wordpress-developer',
+  'how-a-graphic-design-agency-can-fix-your-start-up-mistakes',
+  'how-does-online-auction-work',
+  'how-to-choose-erp-system',
+  'how-to-choose-the-right-digital-marketing-channels-for-your-business',
+  'how-to-conduct-competitor-analysis',
+  'how-to-create-a-process-map',
+  'how-to-create-brand-guidelines',
+  'how-to-increase-online-sales',
+  'how-to-make-a-website-mobile-friendly',
+  'how-to-use-odoo-crm',
+  'how-to-use-odoo-crm-for-effective-customer-relationships',
+  'inventory-management-best-practices',
+  'it-support-trends-2025',
+  'legacy-system-modernisation',
+  'legacy-system-modernization-strategies',
+  'make-a-social-media-app',
+  'marketing-strategy-retail-store',
+  'migration-to-cloud-computing',
+  'minimum-viable-product-examples',
+  'mobile-app-developement-company',
+  'mobile-app-development-tips',
+  'mobile-app-monetization-strategies',
+  'mobile-app-testing-checklist',
+  'mvp-vs-mvvm',
+  'node-js-frameworks',
+  'odoo-erp-complete-guide',
+  'odoo-erp-vs-traditional-erp-which-is-the-best-for-business-in-2025',
+  'on-premise-vs-cloud-erp',
+  'optimizing-cloud-computing',
+  'react-vs-angular-js',
+  'requirements-gathering-techniques',
+  'responsive-web-design-principles',
+  'sample-aws-lambda-function',
+  'sample-digital-marketing-strategy',
+  'scalable-system-architecture',
+  'small-business-erp-solutions',
+  'social-media-marketing-strategies',
+  'software-development-cycle-models',
+  'software-development-life-cycle-example',
+  'software-development-process-phases',
+  'software-development-workflow',
+  'sql-count-group',
+  'startup-business-marketing-strategy',
+  'startup-business-marketing-strategy-playbook',
+  'test-driven-development',
+  'top-7-mistakes-businesses-make-when-building-their-first-mobile-app',
+  'uniting-website-design-and-digital-marketing',
+  'web-application-security-guide',
+  'web-design-company',
+  'web-designing-company',
+  'web-designing-layout',
+  'website-and-app-development-company',
+  'website-development-for-startups',
+  'what-is-customised-software',
+  'what-is-digital-engineering',
+  'woocommerce-development-services',
+]);
+
+const MIGRATED_CASE_STUDY_SLUGS = new Set([
+  'ai-shopping-app-visual-search',
+  'ar-furniture-configurator',
+  'cloud-ehr-multi-specialty',
+  'collaboration-platform-distributed-teams',
+  'crypto-trading-platform',
+  'digital-banking-platform',
+  'digital-wallet-p2p-payments',
+  'fleet-management-route-optimization',
+  'food-delivery-platform',
+  'insurance-claims-ai-portal',
+  'inventory-warehouse-management',
+  'investment-portfolio-app',
+  'learning-management-system-university',
+  'omnichannel-ecommerce-platform',
+  'patient-engagement-app',
+  'production-planning-mrp-automotive',
+  'property-management-erp-portal',
+  'quality-control-dashboard-spc',
+  'saas-mvp-project-management',
+  'secure-telemedicine-platform',
+  'shipment-tracking-last-mile',
+  'student-portal-mobile-app',
+  'supplier-management-procurement',
+  'virtual-tours-ai-listings',
+  'warehouse-automation-robotics',
+]);
+
+export function getMigrationRedirectLocation(requestUrl) {
+  const url = new URL(requestUrl);
+  const pathname = normalizePathname(url.pathname);
+  const exactTarget = EXACT_REDIRECTS.get(pathname);
+
+  if (exactTarget) {
+    return createRedirectLocation(url, exactTarget);
+  }
+
+  const rootSlug = getRootSlug(pathname);
+  if (rootSlug && MIGRATED_BLOG_SLUGS.has(rootSlug)) {
+    return createRedirectLocation(url, `/insights/${rootSlug}/`);
+  }
+
+  const blogSlug = getSingleSegmentSplat(pathname, '/blogs');
+  if (blogSlug && MIGRATED_BLOG_SLUGS.has(blogSlug)) {
+    return createRedirectLocation(url, `/insights/${blogSlug}/`);
+  }
+
+  const caseStudySlug = getSingleSegmentSplat(pathname, '/casestudy');
+  if (caseStudySlug && MIGRATED_CASE_STUDY_SLUGS.has(caseStudySlug)) {
+    return createRedirectLocation(url, `/work/${caseStudySlug}/`);
+  }
+
+  return null;
+}
+
+function normalizePathname(pathname) {
+  if (pathname === '/') {
+    return pathname;
+  }
+
+  return pathname.replace(/\/+$/, '');
+}
+
+function getRootSlug(pathname) {
+  if (pathname === '/' || pathname.slice(1).includes('/')) {
+    return null;
+  }
+
+  return pathname.slice(1);
+}
+
+function getSingleSegmentSplat(pathname, prefix) {
+  if (!pathname.startsWith(`${prefix}/`)) {
+    return null;
+  }
+
+  const splat = pathname.slice(prefix.length + 1);
+  return splat && !splat.includes('/') ? splat : null;
+}
+
+function createRedirectLocation(url, targetPath) {
+  const target = new URL(targetPath, url.origin);
+  target.search = url.search;
+
+  if (normalizePathname(target.pathname) === normalizePathname(url.pathname)) {
+    return null;
+  }
+
+  return target.toString();
+}

--- a/tests/migration-redirects.test.mjs
+++ b/tests/migration-redirects.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  getMigrationRedirectLocation,
+  PERMANENT_REDIRECT_STATUS,
+} from '../src/worker/migration-redirects.js';
+
+const origin = 'https://kpinfo.tech';
+
+function redirectFor(path) {
+  return getMigrationRedirectLocation(`${origin}${path}`);
+}
+
+describe('migration redirects', () => {
+  it('uses permanent redirects', () => {
+    assert.equal(PERMANENT_REDIRECT_STATUS, 301);
+  });
+
+  it('redirects old service slugs to current service routes', () => {
+    assert.equal(
+      redirectFor('/services/web-application-development/'),
+      `${origin}/services/custom-software-development/`,
+    );
+    assert.equal(
+      redirectFor('/services/erp-solutions'),
+      `${origin}/services/erp-software/`,
+    );
+    assert.equal(
+      redirectFor('/services/ai-automation/'),
+      `${origin}/services/ai-automation-agents/`,
+    );
+  });
+
+  it('falls ambiguous removed service pages back to existing current service routes', () => {
+    assert.equal(
+      redirectFor('/services/mobile-app-development/'),
+      `${origin}/services/custom-software-development/`,
+    );
+    assert.equal(
+      redirectFor('/services/ui-ux-design/'),
+      `${origin}/services/custom-software-development/`,
+    );
+    assert.equal(
+      redirectFor('/mobile-web-app/'),
+      `${origin}/services/custom-software-development/`,
+    );
+    assert.equal(redirectFor('/odoo-crm/'), `${origin}/services/erp-software/`);
+  });
+
+  it('preserves query strings while normalizing trailing slashes', () => {
+    assert.equal(
+      redirectFor('/career?utm_source=old-site'),
+      `${origin}/careers/?utm_source=old-site`,
+    );
+    assert.equal(
+      redirectFor('/blogs/node-js-frameworks/?utm_campaign=migration'),
+      `${origin}/insights/node-js-frameworks/?utm_campaign=migration`,
+    );
+  });
+
+  it('redirects only known migrated blog and case-study slugs', () => {
+    assert.equal(
+      redirectFor('/node-js-frameworks/'),
+      `${origin}/insights/node-js-frameworks/`,
+    );
+    assert.equal(
+      redirectFor('/blogs/node-js-frameworks/'),
+      `${origin}/insights/node-js-frameworks/`,
+    );
+    assert.equal(
+      redirectFor('/casestudy/ai-shopping-app-visual-search/'),
+      `${origin}/work/ai-shopping-app-visual-search/`,
+    );
+    assert.equal(redirectFor('/blogs/not-a-migrated-post/'), null);
+    assert.equal(redirectFor('/casestudy/not-a-known-case-study/'), null);
+  });
+
+  it('does not redirect current target routes back to old routes', () => {
+    assert.equal(redirectFor('/services/erp-software/'), null);
+    assert.equal(redirectFor('/services/custom-software-development/'), null);
+    assert.equal(redirectFor('/insights/node-js-frameworks/'), null);
+    assert.equal(redirectFor('/work/ai-shopping-app-visual-search/'), null);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,12 +3,36 @@
 # The adapter's @cloudflare/vite-plugin generates wrangler.json
 # in dist/server/ with the correct assets directory and entrypoint.
 name = "website"
+main = "src/worker.js"
 compatibility_date = "2026-02-11"
 compatibility_flags = ["nodejs_compat", "disable_nodejs_process_v2"]
 
 # Let non-static requests fall through to the Worker (default behavior).
 # The Astro Worker handles SSR routes (e.g. /studio) and serves 404.astro for unknown routes.
 [assets]
+run_worker_first = [
+  "/services/*",
+  "/erp-software",
+  "/erp-software/",
+  "/odoo-crm",
+  "/odoo-crm/",
+  "/mobile-web-app",
+  "/mobile-web-app/",
+  "/career",
+  "/career/",
+  "/blogs",
+  "/blogs/*",
+  "/casestudy",
+  "/casestudy/*",
+  "/hire-wordpress-developer",
+  "/hire-wordpress-developer/",
+  "/hire-laravel-developer",
+  "/hire-laravel-developer/",
+  "/hire-react-js-developer",
+  "/hire-react-js-developer/",
+  "/kp-infotech-faqs",
+  "/kp-infotech-faqs/",
+]
 
 # Environment variables (available at build time + runtime)
 [vars]


### PR DESCRIPTION
## Summary
- Adds a custom Cloudflare Worker entry that runs migration redirects before delegating to Astro.
- Adds a maintainable redirect resolver for high-priority KP Infotech legacy URLs, preserving query strings and avoiding redirect loops.
- Adds regression coverage for service, blog, case-study, root blog, trailing-slash, and loop behavior.

## Why
The site is deployed as a Cloudflare Worker named website, so relying only on public/_redirects can miss migration redirects before Astro handles requests.

## Validation
- 
ode --test tests\migration-redirects.test.mjs`n- PUBLIC_SANITY_PROJECT_ID=5rux0mv2 PUBLIC_SANITY_DATASET=production npm run build`n
Build completed with existing Astro warnings about duplicate generated insight routes: /insights/category/design and /insights/uniting-website-design-and-digital-marketing.