### PR TITLE
[codex] Add business process automation redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -65,6 +65,7 @@
 /requirements-gathering-techniques/                                         /insights/requirements-gathering-techniques/                                         301
 /legacy-system-modernization-strategies/                                    /insights/legacy-system-modernization-strategies/                                    301
 /affordable-web-hosting-solutions-for-businesses/                           /insights/affordable-web-hosting-solutions-for-businesses/                           301
+/business-process-automation-examples/                                      /insights/business-process-automation-examples/                                      301
 /business-process-automation-tools/                                         /insights/business-process-automation-tools/                                         301
 /how-to-use-odoo-crm/                                                       /insights/how-to-use-odoo-crm/                                                       301
 /web-designing-layout/                                                      /insights/web-designing-layout/                                                      301

--- a/src/worker/migration-redirects.js
+++ b/src/worker/migration-redirects.js
@@ -46,6 +46,7 @@ const MIGRATED_BLOG_SLUGS = new Set([
   'best-seo-tools-for-small-businesses',
   'best-web-application-frameworks',
   'brand-style-guide-template',
+  'business-process-automation-examples',
   'business-process-automation-tools',
   'business-process-improvement-methods',
   'cloud-application-architecture-diagram',

--- a/tests/migration-redirects.test.mjs
+++ b/tests/migration-redirects.test.mjs
@@ -69,6 +69,10 @@ describe('migration redirects', () => {
       `${origin}/insights/node-js-frameworks/`,
     );
     assert.equal(
+      redirectFor('/business-process-automation-examples/'),
+      `${origin}/insights/business-process-automation-examples/`,
+    );
+    assert.equal(
       redirectFor('/casestudy/ai-shopping-app-visual-search/'),
       `${origin}/work/ai-shopping-app-visual-search/`,
     );


### PR DESCRIPTION
## Summary

- Add the missing legacy blog redirect for `/business-process-automation-examples/` to the Worker migration allowlist.
- Add the matching `_redirects` fallback/documentation entry.
- Cover the new root-level blog slug with the existing migration redirect regression test.

## Why

The migration audit found a live WordPress post, `/business-process-automation-examples/`, that was not present in the redirect map. Without this redirect, the high-value legacy URL would not route to the new `/insights/` structure after launch.

A Sanity draft was also created separately for `business-process-automation-examples`; it should be reviewed and published before this redirect ships live.

## Validation

- `node --test tests\migration-redirects.test.mjs`