### PR TITLE
[codex] Fix final SEO migration QA blockers

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,8 +1,8 @@
 # ─── Service page redirects (old WP slugs → new Astro slugs) ─────────────────
 /services/website-design/          /services/web-development/    301
 /services/graphics-design/         /services/ui-ux-design/       301
-/services/erp-software/            /services/erp-solutions/      301
-/services/erp-software/odoo-crm/   /services/erp-solutions/      301
+/services/erp-solutions/           /services/erp-software/       301
+/services/erp-software/odoo-crm/   /services/erp-software/       301
 /services/mobile-web-app/          /services/mobile-apps/        301
 /services/marketing/               /services/digital-marketing/  301
 

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -35,7 +35,7 @@ const jobPostingSchema = hasJobs
 
 <BaseLayout
   title="Careers"
-  description="Join KP Infotech — we're building the future of digital experiences. Explore open positions and apply."
+  description="Join KP Infotech to build custom software, ERP, automation, AI, and cloud systems for growing businesses."
 >
   <!-- Schema.org structured data for job postings -->
   {hasJobs && (
@@ -48,7 +48,7 @@ const jobPostingSchema = hasJobs
   <PageHero variant="inner">
     <h1>Join Our <span class="text-[var(--accent)]">Team</span></h1>
     <p class="page-hero__description">
-      We're building the future of digital experiences. Find your place at KP Infotech.
+      We're building practical systems for growing businesses. Find your place at KP Infotech.
     </p>
   </PageHero>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -59,7 +59,7 @@ const contactSchema = {
   "@context": "https://schema.org",
   "@type": "ContactPage",
   "name": "Contact KP Infotech",
-  "description": "Get in touch with KP Infotech to discuss your digital project. We offer UI/UX design, web development, mobile apps, and ERP solutions.",
+  "description": "Talk to KP Infotech about custom software, Odoo ERP, automation, AI agents, and cloud infrastructure for growing business operations.",
   "url": "https://kpinfo.tech/contact/",
   "mainEntity": {
     "@type": "Organization",
@@ -78,7 +78,7 @@ const contactSchema = {
 
 <BaseLayout
   title="Contact"
-  description="Get in touch with KP Infotech to discuss your digital project. We craft exceptional UI/UX designs, web applications, mobile apps, and enterprise solutions."
+  description="Talk to KP Infotech about custom software, Odoo ERP, automation, AI agents, and cloud infrastructure for growing business operations."
 >
   <!-- Schema.org structured data -->
   <Fragment slot="head">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,6 +61,11 @@ const stats = siteSettings?.stats?.map((stat: any) => ({
 
 // Default description for hero
 const heroDescription = "KP Infotech helps growing B2B teams replace spreadsheets, manual workflows, and disconnected tools with custom software, Odoo ERP, business automation, AI agents, and cloud infrastructure built around how their operations actually work.";
+const expectedHeroHeadline = "Custom Software, ERP & Automation Systems for Growing Businesses";
+const legacyHeroHeadline = "We craft *digital experiences* that drive growth";
+const heroHeadline = siteSettings?.heroHeadline && siteSettings.heroHeadline !== legacyHeroHeadline
+  ? siteSettings.heroHeadline
+  : expectedHeroHeadline;
 const homeJsonLd = [
   websiteSchema(siteSettings),
 ];
@@ -75,7 +80,7 @@ const homeJsonLd = [
   <!-- Hero Section -->
   <Hero
     tagline={siteSettings?.siteTagline || "Digital Product Studio"}
-    headline={siteSettings?.heroHeadline || "Custom Software, ERP & Automation Systems for Growing Businesses"}
+    headline={heroHeadline}
     description={heroDescription}
     image={homeHeroUrl}
   />


### PR DESCRIPTION
## Summary

- fixes the ERP migration fallback redirect so `/services/erp-solutions/` points to the protected final `/services/erp-software/` URL
- keeps `/services/erp-software/odoo-crm/` redirected into `/services/erp-software/`
- prevents the legacy Sanity homepage headline from overriding the launch H1
- updates stale Contact and Careers metadata away from old digital studio/UI/UX/web/mobile positioning

## Root Cause

Sanity production already has the published ERP service document with title `ERP & Odoo Solutions` and slug `erp-software`, and Astro generates `/services/erp-software/`. The blocker was stale fallback redirect config in `public/_redirects` redirecting the final ERP URL away to `/services/erp-solutions/`, while the Worker redirect map sends `/services/erp-solutions/` back to `/services/erp-software/`.

The stale homepage H1 came from `siteSettings.heroHeadline` in Sanity still returning `We craft *digital experiences* that drive growth`; the page now ignores that known legacy value and renders the launch headline.

## Validation

- `node --test tests\migration-redirects.test.mjs` - 6 passed, 0 failed
- `PUBLIC_SANITY_PROJECT_ID=5rux0mv2 PUBLIC_SANITY_DATASET=production npm run build` - passed

Known build warnings still present:

- `Could not render /insights/category/design from route /insights/category/[slug] as it conflicts with higher priority route /insights/category/[slug].`
- `Could not render /insights/uniting-website-design-and-digital-marketing from route /insights/[slug] as it conflicts with higher priority route /insights/[slug].`
