### PR TITLE
feat: Cloudflare email for forms + Turnstile, drop Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,19 @@ PUBLIC_SANITY_PROJECT_ID=
 PUBLIC_SANITY_DATASET=production
 SANITY_API_TOKEN=
 
-# HubSpot (Phase 2)
+# Cloudflare Turnstile (form anti-spam / bot protection)
+# Create a widget in Cloudflare dashboard → Turnstile to get both keys.
+PUBLIC_TURNSTILE_SITE_KEY=     # public — rendered in the form widget
+TURNSTILE_SECRET_KEY=         # secret — server-side verification (set as a Worker secret in prod)
+
+# Email — Cloudflare Email Sending (NO API key; uses the EMAIL `send_email` binding in wrangler.toml)
+# Onboard the sending domain once: `npx wrangler email sending enable kpinfo.tech`
+CAREERS_EMAIL_TO=careers@kpinfo.tech   # inbox that receives careers applications
+CONTACT_EMAIL_TO=info@kpinfo.tech      # inbox that receives contact-form inquiries
+
+# HubSpot — legacy / unused (contact form does not currently submit to HubSpot)
 PUBLIC_HUBSPOT_PORTAL_ID=
 PUBLIC_HUBSPOT_FORM_ID=
 
-# Analytics (Phase 8)
+# Analytics — GA4 (not yet wired into the site)
 PUBLIC_GA_MEASUREMENT_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "gsap": "^3.14.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "resend": "^6.10.0",
         "sanity": "^5.20.0",
         "simple-icons": "^16.16.0",
         "styled-components": "^6.3.12",
@@ -8284,12 +8283,6 @@
       "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "license": "CC0-1.0"
     },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -11167,12 +11160,6 @@
       "dependencies": {
         "fastest-levenshtein": "^1.0.7"
       }
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -15149,12 +15136,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/postal-mime": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
-      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
-      "license": "MIT-0"
-    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -15960,27 +15941,6 @@
       "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
-    "node_modules/resend": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.14.0.tgz",
-      "integrity": "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==",
-      "license": "MIT",
-      "dependencies": {
-        "postal-mime": "2.7.4",
-        "standardwebhooks": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -16741,16 +16701,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "gsap": "^3.14.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "resend": "^6.10.0",
     "sanity": "^5.20.0",
     "simple-icons": "^16.16.0",
     "styled-components": "^6.3.12",

--- a/src/components/sections/ContactFormSection.astro
+++ b/src/components/sections/ContactFormSection.astro
@@ -55,6 +55,10 @@ const budgetRanges = [
   { value: "50k-plus", label: "$50,000+" },
   { value: "not-sure", label: "Not sure yet" }
 ];
+
+// Cloudflare Turnstile site key (public). When unset, the widget is omitted and
+// the server skips Turnstile verification.
+const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 ---
 
 <section class="contact-form-section">
@@ -138,6 +142,11 @@ const budgetRanges = [
       <h2 class="contact-form__title">Send Us a Message</h2>
 
       <form class="contact-form" id="contact-form" method="POST">
+        <!-- Honeypot — hidden from humans; bots that auto-fill it are silently dropped -->
+        <div class="hp-field" aria-hidden="true">
+          <label>Leave this field empty<input type="text" name="website" tabindex="-1" autocomplete="off" /></label>
+        </div>
+
         <div class="contact-form__grid">
           <!-- Name -->
           <div class="form-group">
@@ -230,6 +239,12 @@ const budgetRanges = [
             ></textarea>
           </div>
 
+          {turnstileSiteKey && (
+            <div class="form-group form-group--full turnstile-wrapper">
+              <div class="cf-turnstile" data-sitekey={turnstileSiteKey} data-theme="dark"></div>
+            </div>
+          )}
+
           <!-- Submit Button -->
           <div class="form-group form-group--full">
             <button type="submit" class="form-submit">
@@ -239,6 +254,10 @@ const budgetRanges = [
               </span>
               <span class="form-submit__fill"></span>
             </button>
+          </div>
+
+          <div class="form-group form-group--full">
+            <p class="form-status" id="contact-status" role="status" aria-live="polite"></p>
           </div>
         </div>
       </form>
@@ -530,6 +549,33 @@ const budgetRanges = [
   .form-submit:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 4px;
+  }
+
+  /* Honeypot (visually hidden), Turnstile spacing, and status message */
+  .hp-field {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  .turnstile-wrapper {
+    margin-top: 0.5rem;
+  }
+
+  .form-status {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 300;
+  }
+
+  .form-status--success {
+    color: var(--success);
+  }
+
+  .form-status--error {
+    color: var(--error);
   }
 
   /* Responsive */

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,49 @@
+/// <reference types="astro/client" />
+
+// ---------------------------------------------------------------------------
+// Cloudflare Email Sending binding (env.EMAIL) — see wrangler.toml [[send_email]]
+// ---------------------------------------------------------------------------
+
+interface EmailAttachment {
+  /** Raw string for text files, ArrayBuffer/ArrayBufferView for binary (e.g. PDF). */
+  content: string | ArrayBuffer | ArrayBufferView;
+  filename: string;
+  type?: string;
+  disposition?: 'attachment' | 'inline';
+  contentId?: string;
+}
+
+interface EmailSendOptions {
+  to: string | string[];
+  from: string | { email: string; name?: string };
+  subject: string;
+  html?: string;
+  text?: string;
+  replyTo?: string;
+  cc?: string | string[];
+  bcc?: string | string[];
+  attachments?: EmailAttachment[];
+  headers?: Record<string, string>;
+}
+
+interface CloudflareEmailBinding {
+  send(options: EmailSendOptions): Promise<{ messageId?: string }>;
+}
+
+/** Worker runtime env: bindings + vars + secrets, available via locals.runtime.env. */
+interface CloudflareEnv {
+  EMAIL: CloudflareEmailBinding;
+  TURNSTILE_SECRET_KEY?: string;
+  CAREERS_EMAIL_TO?: string;
+  CONTACT_EMAIL_TO?: string;
+  PUBLIC_SANITY_PROJECT_ID?: string;
+  PUBLIC_SANITY_DATASET?: string;
+  SANITY_API_TOKEN?: string;
+  [key: string]: unknown;
+}
+
+// Astro v6 removed Astro.locals.runtime.env. Worker bindings/secrets/vars are
+// accessed via `import { env } from 'cloudflare:workers'`.
+declare module 'cloudflare:workers' {
+  export const env: CloudflareEnv;
+}

--- a/src/lib/form-utils.ts
+++ b/src/lib/form-utils.ts
@@ -1,0 +1,75 @@
+// Shared helpers for form-handling API routes (careers, contact).
+
+/** Best-effort client IP from Cloudflare / proxy headers. */
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+    'unknown'
+  );
+}
+
+interface RateEntry {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * In-memory, per-route rate limiter. State lives in a single Worker isolate and
+ * is not durable, so treat this as a best-effort throttle, not a guarantee.
+ */
+export function createRateLimiter(max: number, windowMs: number) {
+  const map = new Map<string, RateEntry>();
+
+  return {
+    isRateLimited(ip: string): boolean {
+      const entry = map.get(ip);
+      if (!entry || Date.now() > entry.resetAt) return false;
+      return entry.count >= max;
+    },
+    recordSubmission(ip: string): void {
+      const now = Date.now();
+      const entry = map.get(ip);
+      if (!entry || now > entry.resetAt) {
+        map.set(ip, { count: 1, resetAt: now + windowMs });
+      } else {
+        entry.count += 1;
+      }
+    },
+  };
+}
+
+/** Verify a Cloudflare Turnstile token server-side. */
+export async function verifyTurnstile(token: string, secretKey: string): Promise<boolean> {
+  const body = new URLSearchParams();
+  body.append('secret', secretKey);
+  body.append('response', token);
+
+  const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    body,
+  });
+
+  if (!response.ok) return false;
+
+  const data = (await response.json()) as { success: boolean };
+  return data.success === true;
+}
+
+/** Escape user-supplied text for safe interpolation into HTML email bodies. */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/** JSON Response helper. */
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/pages/api/careers/apply.ts
+++ b/src/pages/api/careers/apply.ts
@@ -1,74 +1,19 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import { Resend } from 'resend';
+import {
+  getClientIp,
+  createRateLimiter,
+  verifyTurnstile,
+  escapeHtml,
+  json,
+} from '../../../lib/form-utils';
+// Astro 6 + @astrojs/cloudflare: Worker bindings/secrets/vars come from here,
+// NOT Astro.locals.runtime.env (removed in v6). `env` resolves per-request.
+import { env } from 'cloudflare:workers';
 
-// ---------------------------------------------------------------------------
-// Rate limiting — in-memory Map, max 3 submissions per IP per hour
-// ---------------------------------------------------------------------------
-
-interface RateEntry {
-  count: number;
-  resetAt: number;
-}
-
-const rateLimitMap = new Map<string, RateEntry>();
-const RATE_LIMIT_MAX = 3;
-const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
-
-function getClientIp(request: Request): string {
-  return (
-    request.headers.get('cf-connecting-ip') ||
-    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
-    'unknown'
-  );
-}
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-
-  if (!entry || now > entry.resetAt) {
-    // No entry or window has expired — not limited yet (entry will be created on record)
-    return false;
-  }
-
-  return entry.count >= RATE_LIMIT_MAX;
-}
-
-function recordSubmission(ip: string): void {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-  } else {
-    entry.count += 1;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Cloudflare Turnstile verification
-// ---------------------------------------------------------------------------
-
-async function verifyTurnstile(token: string, secretKey: string): Promise<boolean> {
-  const body = new URLSearchParams();
-  body.append('secret', secretKey);
-  body.append('response', token);
-
-  const response = await fetch(
-    'https://challenges.cloudflare.com/turnstile/v0/siteverify',
-    {
-      method: 'POST',
-      body,
-    }
-  );
-
-  if (!response.ok) return false;
-
-  const data = (await response.json()) as { success: boolean };
-  return data.success === true;
-}
+// Rate limiting — 3 submissions per IP per hour (best-effort, per Worker isolate)
+const limiter = createRateLimiter(3, 60 * 60 * 1000);
 
 // ---------------------------------------------------------------------------
 // Allowed MIME types for resume files
@@ -90,11 +35,8 @@ export const POST: APIRoute = async ({ request }) => {
   const ip = getClientIp(request);
 
   // 1. Rate limiting check
-  if (isRateLimited(ip)) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Too many submissions. Please try again later.' }),
-      { status: 429, headers: { 'Content-Type': 'application/json' } }
-    );
+  if (limiter.isRateLimited(ip)) {
+    return json({ success: false, error: 'Too many submissions. Please try again later.' }, 429);
   }
 
   // Parse multipart form data
@@ -102,38 +44,26 @@ export const POST: APIRoute = async ({ request }) => {
   try {
     formData = await request.formData();
   } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Invalid form data.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Invalid form data.' }, 400);
   }
 
   // 2. Honeypot — silently succeed if the hidden "website" field is filled
   const honeypot = formData.get('website');
   if (honeypot && String(honeypot).trim() !== '') {
-    return new Response(
-      JSON.stringify({ success: true }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: true }, 200);
   }
 
   // 3. Cloudflare Turnstile verification (only when secret key is configured)
-  const turnstileSecretKey = import.meta.env.TURNSTILE_SECRET_KEY;
+  const turnstileSecretKey = env.TURNSTILE_SECRET_KEY ?? import.meta.env.TURNSTILE_SECRET_KEY;
   if (turnstileSecretKey) {
     const turnstileToken = formData.get('cf-turnstile-response');
     if (!turnstileToken || String(turnstileToken).trim() === '') {
-      return new Response(
-        JSON.stringify({ success: false, error: 'CAPTCHA verification required.' }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } }
-      );
+      return json({ success: false, error: 'CAPTCHA verification required.' }, 400);
     }
 
     const turnstileValid = await verifyTurnstile(String(turnstileToken), turnstileSecretKey);
     if (!turnstileValid) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'CAPTCHA verification failed. Please try again.' }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } }
-      );
+      return json({ success: false, error: 'CAPTCHA verification failed. Please try again.' }, 400);
     }
   }
 
@@ -145,74 +75,49 @@ export const POST: APIRoute = async ({ request }) => {
   const linkedin = String(formData.get('linkedin') ?? '').trim();
 
   if (!name) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Name is required.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Name is required.' }, 400);
   }
 
   if (!email) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Email is required.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Email is required.' }, 400);
   }
 
   if (!phone) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Phone is required.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Phone is required.' }, 400);
   }
 
   // 5. Resume file validation
   const resumeEntry = formData.get('resume');
 
   if (!resumeEntry || !(resumeEntry instanceof File)) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Resume file is required.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Resume file is required.' }, 400);
   }
 
   const resume = resumeEntry as File;
 
   if (resume.size === 0) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Resume file is empty.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Resume file is empty.' }, 400);
   }
 
   if (resume.size > MAX_FILE_SIZE_BYTES) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Resume file must be smaller than 5 MB.' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Resume file must be smaller than 5 MB.' }, 400);
   }
 
   if (!ALLOWED_MIME_TYPES.has(resume.type)) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Resume must be a PDF or Word document (.pdf, .doc, .docx).' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
+    return json({ success: false, error: 'Resume must be a PDF or Word document (.pdf, .doc, .docx).' }, 400);
   }
 
-  // 6. Send email via Resend
-  const resendApiKey = import.meta.env.RESEND_API_KEY;
-  if (!resendApiKey) {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Email service is not configured.' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
+  // 6. Send email via Cloudflare Email Sending (env.EMAIL binding — no API key)
+  const emailBinding = env.EMAIL;
+  if (!emailBinding) {
+    return json({ success: false, error: 'Email service is not configured.' }, 500);
   }
-
-  const resend = new Resend(resendApiKey);
 
   const careersEmailTo =
-    import.meta.env.CAREERS_EMAIL_TO || 'careers@kpinfo.tech';
+    env.CAREERS_EMAIL_TO || import.meta.env.CAREERS_EMAIL_TO || 'careers@kpinfo.tech';
 
-  const resumeBuffer = Buffer.from(await resume.arrayBuffer());
+  // Cloudflare's binding takes binary attachment content as an ArrayBuffer.
+  const resumeContent = await resume.arrayBuffer();
 
   const emailHtml = `
     <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #333;">
@@ -262,53 +167,46 @@ export const POST: APIRoute = async ({ request }) => {
     </div>
   `;
 
+  // Plain-text alternative — improves deliverability and spam scores.
+  const emailText = [
+    'New Job Application',
+    '',
+    `Position: ${position}`,
+    `Name: ${name}`,
+    `Email: ${email}`,
+    `Phone: ${phone}`,
+    linkedin ? `LinkedIn: ${linkedin}` : '',
+    `Resume: attached (${resume.name})`,
+    '',
+    'Submitted from kpinfo.tech/careers',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
   try {
-    const { error } = await resend.emails.send({
-      from: 'KP Infotech Careers <careers@kpinfo.tech>',
+    await emailBinding.send({
       to: careersEmailTo,
+      from: { email: 'careers@kpinfo.tech', name: 'KP Infotech Careers' },
+      replyTo: email,
       subject: `New Application: ${position} — ${name}`,
       html: emailHtml,
+      text: emailText,
       attachments: [
         {
+          content: resumeContent,
           filename: resume.name,
-          content: resumeBuffer,
+          type: resume.type || 'application/octet-stream',
+          disposition: 'attachment',
         },
       ],
     });
-
-    if (error) {
-      console.error('Resend API error:', error);
-      return new Response(
-        JSON.stringify({ success: false, error: 'Failed to send application. Please try again.' }),
-        { status: 500, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-  } catch (err) {
-    console.error('Unexpected error sending email:', err);
-    return new Response(
-      JSON.stringify({ success: false, error: 'An unexpected error occurred. Please try again.' }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
+  } catch (err: any) {
+    console.error('Cloudflare Email send error:', err?.code, err?.message ?? err);
+    return json({ success: false, error: 'Failed to send application. Please try again.' }, 500);
   }
 
   // 7. Record the submission for rate limiting (only after successful send)
-  recordSubmission(ip);
+  limiter.recordSubmission(ip);
 
-  return new Response(
-    JSON.stringify({ success: true }),
-    { status: 200, headers: { 'Content-Type': 'application/json' } }
-  );
+  return json({ success: true }, 200);
 };
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,0 +1,154 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import {
+  getClientIp,
+  createRateLimiter,
+  verifyTurnstile,
+  escapeHtml,
+  json,
+} from '../../lib/form-utils';
+// Astro 6 + @astrojs/cloudflare: Worker bindings/secrets/vars come from here,
+// NOT Astro.locals.runtime.env (removed in v6). `env` resolves per-request.
+import { env } from 'cloudflare:workers';
+
+// Rate limiting — 5 submissions per IP per hour (best-effort, per Worker isolate)
+const limiter = createRateLimiter(5, 60 * 60 * 1000);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const POST: APIRoute = async ({ request }) => {
+  const ip = getClientIp(request);
+
+  // 1. Rate limiting
+  if (limiter.isRateLimited(ip)) {
+    return json({ success: false, error: 'Too many submissions. Please try again later.' }, 429);
+  }
+
+  // Parse form data
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return json({ success: false, error: 'Invalid form data.' }, 400);
+  }
+
+  // 2. Honeypot — silently succeed if the hidden "website" field is filled
+  const honeypot = formData.get('website');
+  if (honeypot && String(honeypot).trim() !== '') {
+    return json({ success: true }, 200);
+  }
+
+  // 3. Cloudflare Turnstile verification (only when the secret key is configured)
+  const turnstileSecretKey = env.TURNSTILE_SECRET_KEY ?? import.meta.env.TURNSTILE_SECRET_KEY;
+  if (turnstileSecretKey) {
+    const token = formData.get('cf-turnstile-response');
+    if (!token || String(token).trim() === '') {
+      return json({ success: false, error: 'CAPTCHA verification required.' }, 400);
+    }
+    const valid = await verifyTurnstile(String(token), turnstileSecretKey);
+    if (!valid) {
+      return json({ success: false, error: 'CAPTCHA verification failed. Please try again.' }, 400);
+    }
+  }
+
+  // 4. Field validation
+  const name = String(formData.get('name') ?? '').trim();
+  const email = String(formData.get('email') ?? '').trim();
+  const message = String(formData.get('message') ?? '').trim();
+  const company = String(formData.get('company') ?? '').trim();
+  const phone = String(formData.get('phone') ?? '').trim();
+  const projectType = String(formData.get('project_type') ?? '').trim();
+  const budget = String(formData.get('budget') ?? '').trim();
+
+  if (!name) {
+    return json({ success: false, error: 'Name is required.' }, 400);
+  }
+  if (!email || !EMAIL_RE.test(email)) {
+    return json({ success: false, error: 'A valid email address is required.' }, 400);
+  }
+  if (!message) {
+    return json({ success: false, error: 'Message is required.' }, 400);
+  }
+
+  // 5. Send email via Cloudflare Email Sending (env.EMAIL binding — no API key)
+  const emailBinding = env.EMAIL;
+  if (!emailBinding) {
+    return json({ success: false, error: 'Email service is not configured.' }, 500);
+  }
+
+  const contactEmailTo =
+    env.CONTACT_EMAIL_TO || import.meta.env.CONTACT_EMAIL_TO || 'info@kpinfo.tech';
+
+  // Summary rows (skip empty optional fields)
+  const fields: Array<[string, string]> = [
+    ['Name', name],
+    ['Email', email],
+  ];
+  if (company) fields.push(['Company', company]);
+  if (phone) fields.push(['Phone', phone]);
+  if (projectType) fields.push(['Project Type', projectType]);
+  if (budget) fields.push(['Budget', budget]);
+
+  const rowsHtml = fields
+    .map(
+      ([label, value]) => `
+          <tr>
+            <td style="padding: 10px 12px; background: #f5f5f5; font-weight: bold; width: 30%; border: 1px solid #e0e0e0;">${escapeHtml(label)}</td>
+            <td style="padding: 10px 12px; border: 1px solid #e0e0e0;">${escapeHtml(value)}</td>
+          </tr>`
+    )
+    .join('');
+
+  const emailHtml = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; color: #333;">
+      <h2 style="color: #1a1a1a; border-bottom: 2px solid #c9a87c; padding-bottom: 12px;">
+        New Contact Inquiry
+      </h2>
+
+      <table style="width: 100%; border-collapse: collapse; margin-top: 20px;">
+        <tbody>
+          ${rowsHtml}
+          <tr>
+            <td style="padding: 10px 12px; background: #f5f5f5; font-weight: bold; border: 1px solid #e0e0e0; vertical-align: top;">Message</td>
+            <td style="padding: 10px 12px; border: 1px solid #e0e0e0; white-space: pre-wrap;">${escapeHtml(message)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p style="margin-top: 24px; font-size: 12px; color: #888;">
+        Submitted from kpinfo.tech/contact
+      </p>
+    </div>
+  `;
+
+  const emailText = [
+    'New Contact Inquiry',
+    '',
+    ...fields.map(([label, value]) => `${label}: ${value}`),
+    '',
+    'Message:',
+    message,
+    '',
+    'Submitted from kpinfo.tech/contact',
+  ].join('\n');
+
+  try {
+    await emailBinding.send({
+      to: contactEmailTo,
+      from: { email: 'noreply@kpinfo.tech', name: 'KP Infotech Website' },
+      replyTo: email,
+      subject: `New inquiry from ${name}`,
+      html: emailHtml,
+      text: emailText,
+    });
+  } catch (err: any) {
+    console.error('Cloudflare Email send error (contact):', err?.code, err?.message ?? err);
+    return json({ success: false, error: 'Failed to send your message. Please try again.' }, 500);
+  }
+
+  // 6. Record submission only after a successful send
+  limiter.recordSubmission(ip);
+
+  return json({ success: true }, 200);
+};

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -12,6 +12,10 @@ import { activeJobListingsQuery } from '../../lib/queries';
 const jobs = await client.fetch(activeJobListingsQuery) || [];
 const hasJobs = jobs.length > 0;
 
+// Cloudflare Turnstile site key (public). When unset, the widget is omitted and
+// the server skips Turnstile verification.
+const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
+
 // Build JobPosting schema for structured data
 const jobPostingSchema = hasJobs
   ? jobs.map((job: any) => ({
@@ -153,8 +157,12 @@ const jobPostingSchema = hasJobs
           </div>
         </div>
 
-        <!-- Turnstile widget placeholder -->
-        <div id="turnstile-container" class="turnstile-wrapper"></div>
+        <!-- Cloudflare Turnstile widget (omitted when no site key is configured) -->
+        {turnstileSiteKey && (
+          <div class="turnstile-wrapper">
+            <div class="cf-turnstile" data-sitekey={turnstileSiteKey} data-theme="dark"></div>
+          </div>
+        )}
 
         <div class="form-actions">
           <Button variant="primary" type="submit">
@@ -180,6 +188,10 @@ const jobPostingSchema = hasJobs
     buttonText="Get in Touch"
     buttonHref="/contact/"
   />
+
+  {turnstileSiteKey && (
+    <script is:inline src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  )}
 </BaseLayout>
 
 <style>
@@ -609,12 +621,19 @@ const jobPostingSchema = hasJobs
         form.reset();
         if (fileText) fileText.textContent = 'Choose file or drag here';
         if (fileArea) fileArea.classList.remove('file-upload--has-file');
+        if (typeof (window as any).turnstile !== 'undefined') {
+          (window as any).turnstile.reset();
+        }
 
       } catch (error: any) {
         console.error('Form error:', error);
         if (errorMsg) {
           errorMsg.textContent = error.message || 'Something went wrong. Please try again.';
           errorMsg.style.display = 'block';
+        }
+        // Turnstile tokens are single-use — reset so the user can retry.
+        if (typeof (window as any).turnstile !== 'undefined') {
+          (window as any).turnstile.reset();
         }
       } finally {
         if (submitBtn) submitBtn.disabled = false;

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -74,6 +74,10 @@ const contactSchema = {
     }
   }
 };
+
+// Cloudflare Turnstile site key (public). When unset, no widget renders and the
+// server skips Turnstile verification.
+const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 ---
 
 <BaseLayout
@@ -109,70 +113,65 @@ const contactSchema = {
     country={addressLine2}
     socialLinks={siteSettings?.socialLinks}
   />
+
+  {turnstileSiteKey && (
+    <script is:inline src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  )}
 </BaseLayout>
 
 <script>
-  // Form handling with client-side validation and future HubSpot integration
-  const form = document.getElementById('contact-form') as HTMLFormElement;
+  const form = document.getElementById('contact-form') as HTMLFormElement | null;
+  const statusEl = document.getElementById('contact-status');
+
+  function setStatus(message: string, type: 'success' | 'error' | '') {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.className = 'form-status' + (type ? ` form-status--${type}` : '');
+  }
+
+  function resetTurnstile() {
+    const t = (window as any).turnstile;
+    if (typeof t !== 'undefined') t.reset();
+  }
 
   if (form) {
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
 
       const submitButton = form.querySelector('.form-submit') as HTMLButtonElement;
-      const originalText = submitButton.querySelector('.form-submit__text')?.textContent;
+      const textSpan = submitButton?.querySelector('.form-submit__text');
+      const originalText = textSpan?.textContent || 'Send Message';
 
-      // Update button state
       submitButton.disabled = true;
-      const textSpan = submitButton.querySelector('.form-submit__text');
       if (textSpan) textSpan.textContent = 'Sending...';
-
-      // Collect form data
-      const formData = new FormData(form);
-      const data = Object.fromEntries(formData.entries());
+      setStatus('', '');
 
       try {
-        // For now, log the data - replace with HubSpot API integration
-        console.log('Form submitted:', data);
+        const response = await fetch('/api/contact', {
+          method: 'POST',
+          body: new FormData(form),
+        });
+        const result = await response.json().catch(() => ({ success: false }));
 
-        // TODO: HubSpot Forms API integration
-        // const response = await fetch(
-        //   `https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`,
-        //   {
-        //     method: 'POST',
-        //     headers: { 'Content-Type': 'application/json' },
-        //     body: JSON.stringify({
-        //       fields: [
-        //         { name: 'firstname', value: data.name },
-        //         { name: 'email', value: data.email },
-        //         { name: 'company', value: data.company || '' },
-        //         { name: 'phone', value: data.phone || '' },
-        //         { name: 'project_type', value: data.project_type || '' },
-        //         { name: 'budget', value: data.budget || '' },
-        //         { name: 'message', value: data.message },
-        //       ],
-        //     }),
-        //   }
-        // );
+        if (!response.ok || !result.success) {
+          throw new Error(result.error || 'Something went wrong. Please try again.');
+        }
 
-        // Simulate success
         if (textSpan) textSpan.textContent = 'Message Sent!';
+        setStatus("Thanks — we've received your message and will be in touch.", 'success');
         form.reset();
+        resetTurnstile();
 
-        // Reset button after delay
         setTimeout(() => {
-          if (textSpan) textSpan.textContent = originalText || 'Send Message';
+          if (textSpan) textSpan.textContent = originalText;
           submitButton.disabled = false;
         }, 3000);
-
-      } catch (error) {
-        console.error('Form submission error:', error);
-        if (textSpan) textSpan.textContent = 'Error - Try Again';
+      } catch (error: any) {
+        setStatus(error?.message || 'Something went wrong. Please try again.', 'error');
+        if (textSpan) textSpan.textContent = originalText;
         submitButton.disabled = false;
-
-        setTimeout(() => {
-          if (textSpan) textSpan.textContent = originalText || 'Send Message';
-        }, 3000);
+        // Turnstile tokens are single-use — reset so the user can retry.
+        resetTurnstile();
       }
     });
   }

--- a/src/pages/privacy-policy/index.astro
+++ b/src/pages/privacy-policy/index.astro
@@ -40,7 +40,7 @@ import PageHero from '../../components/sections/PageHero.astro';
         <li><strong>HubSpot</strong> — for form handling and customer relationship management</li>
         <li><strong>Sanity</strong> — for content management (no user data stored)</li>
         <li><strong>Cloudflare</strong> — for website hosting, security, and performance</li>
-        <li><strong>Resend</strong> — for transactional email delivery</li>
+        <li><strong>Cloudflare Email</strong> — for transactional email delivery</li>
       </ul>
 
       <h3>5. Data Retention</h3>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,3 +38,8 @@ run_worker_first = [
 [vars]
 PUBLIC_SANITY_PROJECT_ID = "5rux0mv2"
 PUBLIC_SANITY_DATASET = "production"
+
+# Cloudflare Email Sending — exposes env.EMAIL.send() to the Worker (no API key needed).
+# Onboard the sending domain once: `npx wrangler email sending enable kpinfo.tech`
+[[send_email]]
+name = "EMAIL"


### PR DESCRIPTION
## Summary
- Contact form now sends email via Cloudflare Email Sending (env.EMAIL) — it previously faked success and silently discarded inquiries.
- Careers form switched from Resend to the same Cloudflare send_email binding.
- Cloudflare Turnstile widgets wired on both forms (gated on PUBLIC_TURNSTILE_SITE_KEY); honeypot and rate-limit retained.
- Removed the resend dependency; updated the privacy policy and .env.example.
- Fixed Astro 6 env access via import { env } from cloudflare:workers (locals.runtime.env was removed in v6).

## Required before it works in prod
- Onboard the sending domain: npx wrangler email sending enable kpinfo.tech
- Set PUBLIC_TURNSTILE_SITE_KEY (build-time, inlined), TURNSTILE_SECRET_KEY (Worker secret), and optionally CONTACT_EMAIL_TO / CAREERS_EMAIL_TO
- Deploy — careers resume attachments only deliver once deployed, not in local astro dev

## Verification
- npm run build passes; the send_email binding appears in the generated dist/server/wrangler.json
- Contact endpoint verified in dev: invalid input returns 400, honeypot returns a silent 200, valid input returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)