### PR TITLE
SEO entity/NAP unification + analytics event follow-ups

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,6 +2,7 @@
 import { Icon } from 'astro-icon/components';
 import { client, urlFor, isSvgAsset } from '../lib/sanity';
 import { footerServicesQuery, footerIndustriesQuery } from '../lib/queries';
+import { ORG_EMAIL, ORG_ADDRESS_DISPLAY } from '../lib/seo';
 import type { SanityImageSource } from '@sanity/image-url/lib/types/types';
 
 interface SocialLinks {
@@ -26,9 +27,9 @@ const {
   siteName = 'KP Infotech',
   logo,
   footerText = 'Crafting digital experiences that elevate brands and drive measurable business growth.',
-  contactEmail = 'hello@kpinfo.tech',
+  contactEmail = ORG_EMAIL,
   contactPhone,
-  address = 'Ahmedabad, India',
+  address = ORG_ADDRESS_DISPLAY,
   socialLinks = {},
 } = Astro.props;
 

--- a/src/components/sections/FeaturedWork.astro
+++ b/src/components/sections/FeaturedWork.astro
@@ -84,7 +84,7 @@ function getImageUrl(image: any): string | null {
           <p class="empty-card__description">
             We're preparing case studies of our best projects. Stay tuned.
           </p>
-          <Button variant="primary" href="/contact/">
+          <Button variant="primary" href="/contact/" data-cta="cta" data-location="featured_work" data-label="Contact Us">
             Contact Us
           </Button>
         </div>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -25,7 +25,7 @@ const { tagline, headline, description, image } = Astro.props;
   <p class="page-hero__description">{description}</p>
 
   <div class="page-hero__actions">
-    <Button href="/contact/" variant="primary">Discuss Your Operations Challenge</Button>
+    <Button href="/contact/" variant="primary" data-cta="cta" data-location="home_hero" data-label="Discuss Your Operations Challenge">Discuss Your Operations Challenge</Button>
     <Button href="/work/" variant="text">View Our Work</Button>
   </div>
 </PageHero>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro';
 import { client } from '../lib/sanity';
 import { siteSettingsQuery } from '../lib/queries';
 import defaultOgFallback from '../assets/hero-placeholder.jpg';
-import { canonicalUrl, jsonLdGraph, organizationSchema, seoImageUrl } from '../lib/seo';
+import { canonicalUrl, jsonLdGraph, organizationSchema, seoImageUrl, ORG_PHONE, ORG_EMAIL, ORG_ADDRESS_DISPLAY } from '../lib/seo';
 import CustomCursor from '../components/effects/CustomCursor.astro';
 import ScrollProgress from '../components/effects/ScrollProgress.astro';
 import WhatsAppButton from '../components/ui/WhatsAppButton.astro';
@@ -171,8 +171,8 @@ const clarityProjectId = import.meta.env.PUBLIC_CLARITY_ID;
     <Navigation
       siteName={siteName}
       logo={siteSettings?.logo}
-      contactPhone={siteSettings?.contactPhone}
-      contactEmail={siteSettings?.contactEmail}
+      contactPhone={siteSettings?.contactPhone || ORG_PHONE}
+      contactEmail={siteSettings?.contactEmail || ORG_EMAIL}
       socialLinks={siteSettings?.socialLinks}
     />
     <main class="flex flex-col gap-10">
@@ -182,12 +182,12 @@ const clarityProjectId = import.meta.env.PUBLIC_CLARITY_ID;
       siteName={siteName}
       logo={siteSettings?.logo}
       footerText={siteSettings?.footerText}
-      contactEmail={siteSettings?.contactEmail}
-      contactPhone={siteSettings?.contactPhone}
-      address={siteSettings?.address}
+      contactEmail={siteSettings?.contactEmail || ORG_EMAIL}
+      contactPhone={siteSettings?.contactPhone || ORG_PHONE}
+      address={siteSettings?.address || ORG_ADDRESS_DISPLAY}
       socialLinks={siteSettings?.socialLinks}
     />
-    <WhatsAppButton phone={siteSettings?.contactPhone} />
+    <WhatsAppButton phone={siteSettings?.contactPhone || ORG_PHONE} />
 
     <!-- Grain/Noise Texture Overlay -->
     <div class="grain-overlay" aria-hidden="true"></div>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -4,6 +4,23 @@ import { getOriginalAssetUrl, isSvgAsset, urlFor } from './sanity';
 export const SITE_URL = 'https://kpinfo.tech';
 const SITE_ORIGIN = new URL(SITE_URL).origin;
 
+// ---------------------------------------------------------------------------
+// Canonical organization identity — single source of truth for NAP + entity.
+// Used as schema values and as fallbacks when Sanity siteSettings are empty so
+// every surface (footer, nav, contact, schema) agrees on one set of facts.
+// ---------------------------------------------------------------------------
+export const ORG_ID = `${SITE_URL}/#organization`;
+export const ORG_NAME = 'KP Infotech';
+export const ORG_EMAIL = 'info@kpinfo.tech';
+export const ORG_PHONE = '+91 86182 79004';
+export const ORG_LOCALITY = 'Ahmedabad';
+export const ORG_REGION = 'Gujarat';
+export const ORG_COUNTRY = 'India';
+export const ORG_COUNTRY_CODE = 'IN';
+export const ORG_ADDRESS_DISPLAY = 'Ahmedabad, Gujarat, India';
+export const ORG_DESCRIPTION =
+  'KP Infotech is a B2B operations technology partner building custom software, business automation, ERP & Odoo solutions, AI automation & agents, and cloud & DevOps for growing businesses.';
+
 type JsonValue =
   | string
   | number
@@ -126,21 +143,32 @@ export function organizationSchema(settings?: any): JsonLdNode {
     ? Object.values(settings.socialLinks).filter((url): url is string => typeof url === 'string' && url.length > 0)
     : [];
 
+  const email = settings?.contactEmail || ORG_EMAIL;
+  const telephone = settings?.contactPhone || ORG_PHONE;
+
   return {
     '@type': 'Organization',
-    '@id': `${SITE_URL}/#organization`,
-    name: settings?.siteName || 'KP Infotech',
+    '@id': ORG_ID,
+    name: settings?.siteName || ORG_NAME,
     url: SITE_URL,
     logo: sanityImageUrl(settings?.logo, 512, 512),
-    email: settings?.contactEmail,
-    telephone: settings?.contactPhone,
-    address: settings?.address
-      ? {
-          '@type': 'PostalAddress',
-          streetAddress: settings.address,
-          addressCountry: 'IN',
-        }
-      : undefined,
+    description: ORG_DESCRIPTION,
+    email,
+    telephone,
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: ORG_LOCALITY,
+      addressRegion: ORG_REGION,
+      addressCountry: ORG_COUNTRY_CODE,
+    },
+    contactPoint: {
+      '@type': 'ContactPoint',
+      contactType: 'sales',
+      telephone,
+      email,
+      areaServed: ['India', 'United States', 'United Kingdom', 'Europe'],
+      availableLanguage: ['English'],
+    },
     sameAs: socialLinks,
   };
 }
@@ -149,9 +177,9 @@ export function websiteSchema(settings?: any): JsonLdNode {
   return {
     '@type': 'WebSite',
     '@id': `${SITE_URL}/#website`,
-    name: settings?.siteName || 'KP Infotech',
+    name: settings?.siteName || ORG_NAME,
     url: SITE_URL,
-    publisher: { '@id': `${SITE_URL}/#organization` },
+    publisher: { '@id': ORG_ID },
   };
 }
 

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -7,6 +7,7 @@ import Button from '../../components/ui/Button.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client } from '../../lib/sanity';
 import { activeJobListingsQuery } from '../../lib/queries';
+import { ORG_ID } from '../../lib/seo';
 
 // Fetch active job listings
 const jobs = await client.fetch(activeJobListingsQuery) || [];
@@ -19,7 +20,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 // Build JobPosting schema for structured data
 const jobPostingSchema = hasJobs
   ? jobs.map((job: any) => ({
-      "@context": "https://schema.org",
       "@type": "JobPosting",
       "title": job.title,
       "employmentType": job.employmentType?.toUpperCase().replace(/\s/g, '_'),
@@ -27,11 +27,8 @@ const jobPostingSchema = hasJobs
         "@type": "Place",
         "address": job.location
       },
-      "hiringOrganization": {
-        "@type": "Organization",
-        "name": "KP Infotech",
-        "sameAs": "https://kpinfo.tech"
-      },
+      // Reference the single canonical Organization rather than a separate one.
+      "hiringOrganization": { "@id": ORG_ID },
       "description": job.tagline
     }))
   : null;
@@ -40,13 +37,8 @@ const jobPostingSchema = hasJobs
 <BaseLayout
   title="Careers"
   description="Join KP Infotech to build custom software, ERP, automation, AI, and cloud systems for growing businesses."
+  jsonLd={jobPostingSchema}
 >
-  <!-- Schema.org structured data for job postings -->
-  {hasJobs && (
-    <Fragment slot="head">
-      <script type="application/ld+json" set:html={JSON.stringify(jobPostingSchema)} />
-    </Fragment>
-  )}
 
   <!-- Hero -->
   <PageHero variant="inner">
@@ -528,6 +520,14 @@ const jobPostingSchema = hasJobs
 <script>
   import { trackEvent } from '../../lib/analytics';
 
+  // Re-init on every load + ClientRouter navigation: Astro module scripts run
+  // once, but the careers DOM is re-created on view-transition swaps, so the
+  // handlers (and job_application_submit) must re-attach. Idempotent via a flag.
+  function initCareers() {
+    const careersForm = document.getElementById('careers-form') as HTMLFormElement | null;
+    if (!careersForm || careersForm.dataset.bound === 'true') return;
+    careersForm.dataset.bound = 'true';
+
   // Auto-fill position from job card click
   document.querySelectorAll('.job-card').forEach((card) => {
     card.addEventListener('click', () => {
@@ -622,7 +622,7 @@ const jobPostingSchema = hasJobs
         if (successMsg) successMsg.style.display = 'block';
         trackEvent('job_application_submit', {
           form_id: 'careers',
-          position: String(formData.get('position') || 'General Application'),
+          position: String(formData.get('position') || 'General Application').slice(0, 100),
         });
         form.reset();
         if (fileText) fileText.textContent = 'Choose file or drag here';
@@ -647,4 +647,7 @@ const jobPostingSchema = hasJobs
       }
     });
   }
+  }
+
+  document.addEventListener('astro:page-load', initCareers);
 </script>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,6 +4,7 @@ import ContactHero from '../components/sections/ContactHero.astro';
 import ContactFormSection from '../components/sections/ContactFormSection.astro';
 import ContactMap from '../components/sections/ContactMap.astro';
 import { client, urlFor } from '../lib/sanity';
+import { ORG_ID, canonicalUrl } from '../lib/seo';
 
 // Fetch site settings and page hero from Sanity
 const siteSettingsQuery = `{
@@ -54,25 +55,15 @@ const addressLine1 = addressLines[0] || "Ahmedabad, Gujarat";
 // Only show addressLine2 if there are actually multiple lines, otherwise empty
 const addressLine2 = addressLines.length > 1 ? addressLines[1] : (addressLines.length === 0 ? "India" : "");
 
-// Schema.org ContactPage structured data
+// Schema.org ContactPage — references the single canonical Organization
+// (#organization) instead of re-declaring it, so search engines and AI answer
+// engines see one entity. Merged into the shared @graph via BaseLayout's jsonLd prop.
 const contactSchema = {
-  "@context": "https://schema.org",
   "@type": "ContactPage",
   "name": "Contact KP Infotech",
   "description": "Talk to KP Infotech about custom software, Odoo ERP, automation, AI agents, and cloud infrastructure for growing business operations.",
-  "url": "https://kpinfo.tech/contact/",
-  "mainEntity": {
-    "@type": "Organization",
-    "name": "KP Infotech",
-    "email": siteSettings?.contactEmail || "info@kpinfo.tech",
-    "telephone": siteSettings?.contactPhone || "+91 86182 79004",
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Ahmedabad",
-      "addressRegion": "Gujarat",
-      "addressCountry": "India"
-    }
-  }
+  "url": canonicalUrl('/contact/'),
+  "mainEntity": { "@id": ORG_ID }
 };
 
 // Cloudflare Turnstile site key (public). When unset, no widget renders and the
@@ -83,12 +74,8 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 <BaseLayout
   title="Contact"
   description="Talk to KP Infotech about custom software, Odoo ERP, automation, AI agents, and cloud infrastructure for growing business operations."
+  jsonLd={contactSchema}
 >
-  <!-- Schema.org structured data -->
-  <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(contactSchema)} />
-  </Fragment>
-
   <ContactHero
     label="Get In Touch"
     headline="Let's Build Something *Great*"
@@ -122,21 +109,27 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 <script>
   import { trackEvent } from '../lib/analytics';
 
-  const form = document.getElementById('contact-form') as HTMLFormElement | null;
-  const statusEl = document.getElementById('contact-status');
+  // Re-init on every load + ClientRouter navigation: Astro module scripts run
+  // once, but the form is re-created on view-transition swaps, so the submit
+  // handler (and its generate_lead event) must re-attach. Idempotent via a flag.
+  function initContactForm() {
+    const form = document.getElementById('contact-form') as HTMLFormElement | null;
+    if (!form || form.dataset.bound === 'true') return;
+    form.dataset.bound = 'true';
 
-  function setStatus(message: string, type: 'success' | 'error' | '') {
-    if (!statusEl) return;
-    statusEl.textContent = message;
-    statusEl.className = 'form-status' + (type ? ` form-status--${type}` : '');
-  }
+    const statusEl = document.getElementById('contact-status');
 
-  function resetTurnstile() {
-    const t = (window as any).turnstile;
-    if (typeof t !== 'undefined') t.reset();
-  }
+    function setStatus(message: string, type: 'success' | 'error' | '') {
+      if (!statusEl) return;
+      statusEl.textContent = message;
+      statusEl.className = 'form-status' + (type ? ` form-status--${type}` : '');
+    }
 
-  if (form) {
+    function resetTurnstile() {
+      const t = (window as any).turnstile;
+      if (typeof t !== 'undefined') t.reset();
+    }
+
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
 
@@ -181,4 +174,6 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
       }
     });
   }
+
+  document.addEventListener('astro:page-load', initContactForm);
 </script>

--- a/src/pages/insights/[slug].astro
+++ b/src/pages/insights/[slug].astro
@@ -7,7 +7,7 @@ import RelatedPosts from '../../components/sections/RelatedPosts.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { blogPostBySlugQuery, publicBlogSlugsQuery } from '../../lib/queries';
-import { breadcrumbSchema, canonicalUrl } from '../../lib/seo';
+import { breadcrumbSchema, canonicalUrl, ORG_ID } from '../../lib/seo';
 
 export async function getStaticPaths() {
   const posts = await client.fetch<Array<{ slug: { current: string } }>>(
@@ -84,12 +84,8 @@ const blogJsonLd = [
       name: post.author.name,
       jobTitle: post.author.role,
       sameAs: [post.author.linkedin, post.author.twitter].filter(Boolean),
-    } : {
-      '@type': 'Organization',
-      '@id': 'https://kpinfo.tech/#organization',
-      name: 'KP Infotech',
-    },
-    publisher: { '@id': 'https://kpinfo.tech/#organization' },
+    } : { '@id': ORG_ID },
+    publisher: { '@id': ORG_ID },
     articleSection: post.category?.title,
     keywords: post.tags,
   },

--- a/src/pages/services/[slug].astro
+++ b/src/pages/services/[slug].astro
@@ -9,7 +9,7 @@ import ServiceFAQ from '../../components/sections/ServiceFAQ.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { allServicesQuery, serviceBySlugQuery } from '../../lib/queries';
-import { breadcrumbSchema, canonicalUrl } from '../../lib/seo';
+import { breadcrumbSchema, canonicalUrl, ORG_ID } from '../../lib/seo';
 
 export async function getStaticPaths() {
   const services = await client.fetch<Array<{ slug: { current: string } }>>(allServicesQuery);
@@ -52,7 +52,7 @@ const serviceJsonLd = [
     name: service.title,
     description: seoDescription,
     url: serviceUrl,
-    provider: { '@id': 'https://kpinfo.tech/#organization' },
+    provider: { '@id': ORG_ID },
     serviceType: service.title,
     areaServed: {
       '@type': 'Country',

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -9,7 +9,7 @@ import NextProject from '../../components/sections/NextProject.astro';
 import CTASection from '../../components/sections/CTASection.astro';
 import { client, urlFor } from '../../lib/sanity';
 import { allCaseStudiesQuery, caseStudyBySlugQuery } from '../../lib/queries';
-import { breadcrumbSchema, canonicalUrl } from '../../lib/seo';
+import { breadcrumbSchema, canonicalUrl, ORG_ID } from '../../lib/seo';
 
 export async function getStaticPaths() {
   const caseStudies = await client.fetch<Array<{ slug: { current: string } }>>(allCaseStudiesQuery);
@@ -56,8 +56,8 @@ const caseStudyJsonLd = [
     url: studyUrl,
     dateCreated: study._createdAt,
     dateModified: study._updatedAt,
-    creator: { '@id': 'https://kpinfo.tech/#organization' },
-    publisher: { '@id': 'https://kpinfo.tech/#organization' },
+    creator: { '@id': ORG_ID },
+    publisher: { '@id': ORG_ID },
     about: [
       ...(study.services || []).map((service: any) => service?.title).filter(Boolean),
       ...(study.industries || []).map((industry: any) => industry?.title).filter(Boolean),


### PR DESCRIPTION
## Summary

Completes the analytics + SEO/GEO launch work. **Phase 1** (GA4 + Google Consent Mode v2 + CookieYes + Microsoft Clarity, hostname gating, privacy policy) and the **Phase 2 core event taxonomy** already landed on `main` via #22. This PR contains the remainder:

### Phase 4 — entity / NAP unification (GEO/AEO)
- Canonical organization constants in `src/lib/seo.ts` as the single source of truth (name, email `info@`, phone, locality/region/country `IN`, description, `ORG_ID`).
- Enriched `Organization` schema: structured `PostalAddress`, a `ContactPoint`, and the new ops-tech `description`; constant fallbacks when Sanity is empty.
- **One canonical `#organization` entity, referenced by `@id` everywhere** — `ContactPage.mainEntity`, `JobPosting.hiringOrganization`, `Service.provider`, `CreativeWork.creator/publisher`, `BlogPosting.author`(fallback)/`publisher`, `WebSite.publisher`. `ContactPage` + `JobPosting` moved into the shared `@graph`. No more duplicate-org stubs or hardcoded `#organization` literals.
- NAP fallbacks hardened for Nav/Footer/WhatsApp so a cleared Sanity field can't silently drop the phone / WhatsApp / `tel:` lead links; fixed the Footer's divergent `hello@` + "Ahmedabad, India" defaults.

### Phase 2 follow-ups (from adversarial review)
- **Lead-loss fix:** re-bind the contact + careers form handlers on `astro:page-load` (idempotent) so in-app `ClientRouter` navigation can't drop a form submission (and its `generate_lead` / `job_application_submit` event).
- Track the homepage hero + FeaturedWork CTAs; cap the careers `position` event param.

## Verification
- `npm run build` passes.
- Output checked: homepage / service / blog pages emit exactly **one** `Organization`; case-study pages show 2 (canonical + the client company, correct); no hardcoded `#organization` literals remain; `ContactPoint` + structured address present.
- Analytics gating confirmed off-prod (no `gtag`, `noindex` injected, no console errors).

## Notes / follow-ups (not in this PR)
- Update the stale Sanity copy (`defaultSeoTitle` / `defaultSeoDescription` / `siteTagline` / `footerText`) to the new ops-tech positioning — CMS edit in Studio.
- Before launch: CookieYes dashboard (enable Consent Mode, map Clarity to Analytics category), verify email deliverability (`wrangler email sending enable kpinfo.tech` + DMARC), mark GA4 Key Events, link GA4 ↔ Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)