### PR TITLE
fix: hero centering + About page tweaks (Values numbers, hide Team)

### DIFF
--- a/src/components/sections/HowWeBuild.astro
+++ b/src/components/sections/HowWeBuild.astro
@@ -37,7 +37,7 @@ const num = (step: ProcessStep, i: number) => String(step.stepNumber ?? i + 1).p
   <section class="how-we-build">
     <div class="how-we-build__container site-container">
       <div class="how-we-build__header">
-        <SectionLabel text="Our Process" />
+        <SectionLabel text="Our Process" variant="centered" />
         <h2 class="how-we-build__title">
           <HighlightedText text={heading} />
         </h2>
@@ -113,6 +113,7 @@ const num = (step: ProcessStep, i: number) => String(step.stepNumber ?? i + 1).p
 
   .how-we-build__header {
     margin-bottom: 4rem;
+    text-align: center;
   }
 
   .how-we-build__title {

--- a/src/components/sections/PageHero.astro
+++ b/src/components/sections/PageHero.astro
@@ -65,13 +65,11 @@ const resolvedImage = image || heroPlaceholder;
   }
 
   /* --- Inner page variant: shorter hero ---
-     Top-anchored content (not vertically centred) so every inner page — service,
-     industry, work, blog detail and the listing pages — starts the breadcrumb /
-     eyebrow at the same Y below the fixed header, instead of drifting with the
-     content height. Desktop (tall viewports) restores centring further down. */
+     Content is vertically centred at every breakpoint, matching the desktop
+     layout (the section flex-centres its container). */
   .page-hero--inner {
     min-height: 75vh;
-    align-items: flex-start;
+    align-items: center;
   }
 
   /* --- Background image layer --- */
@@ -212,12 +210,11 @@ const resolvedImage = image || heroPlaceholder;
     }
   }
 
-  /* Laptop / short viewports (13"–16" MacBooks, windowed desktops): wide enough to
-     be desktop-class but too short for a comfortable centred 75vh hero. Give inner
-     heroes the full screen height and top-anchor the content so it clears the fixed
-     header (which the centred layout used to collide with on these heights), and
-     scale the headline to fit. Tall desktop monitors (>1050px) keep the centred,
-     full-size 75vh hero unchanged. */
+  /* Laptop / short viewports (13"–16" MacBooks, windowed desktops): give inner
+     heroes the full screen height (100vh) so they fill these shorter screens, with
+     the content vertically centred (inherits align-items:center from the desktop
+     rule above). The headline is scaled and spacing tightened so the full-size type
+     doesn't overflow. Tall desktop monitors (>1050px) keep the 75vh hero. */
   @media (min-width: 1024px) and (max-height: 1050px) {
     .page-hero--inner {
       min-height: 100vh;
@@ -225,10 +222,6 @@ const resolvedImage = image || heroPlaceholder;
 
     .page-hero--inner .page-hero__container {
       min-height: 100vh;
-      align-items: flex-start;
-      justify-content: flex-start;
-      padding-top: clamp(9.5rem, 20vh, 13rem);
-      padding-bottom: 4rem;
     }
 
     .page-hero__content {

--- a/src/components/sections/Values.astro
+++ b/src/components/sections/Values.astro
@@ -122,7 +122,7 @@ const {
   .value-card__number {
     display: block;
     font-family: var(--font-body), 'Outfit', sans-serif;
-    font-size: 0.75rem;
+    font-size: 0.9375rem;
     font-weight: 400;
     color: var(--accent);
     margin-bottom: 1.5rem;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -60,7 +60,8 @@ const data = await client.fetch<{
 }>(aboutQuery);
 
 const teamMembers = data?.teamMembers || [];
-const showTeam = teamMembers.length > 0;
+// Team section temporarily hidden — see <Team visible={false} /> below. Restore by
+// passing visible={teamMembers.length > 0}.
 
 // Build hero image URL if available
 let aboutHeroUrl: string | undefined;
@@ -142,7 +143,7 @@ const integrityIconUrl = safeUrl(ap?.integrityIcon, 144, 'png') || '/images/valu
   />
 
   <Team
-    visible={showTeam}
+    visible={false}
     members={teamMembers}
     label="Our Team"
     headline="The People Behind the *Work*"


### PR DESCRIPTION
## What & why

Two related batches of UI fixes.

### 1. Inner hero alignment — `PageHero.astro`
Follow-up to #24 (commit 4ef5566), which made inner heroes **top-anchor** their content on laptop-height and smaller viewports. We want them centered like desktop.

- Base `.page-hero--inner` now uses `align-items: center` (was `flex-start`) → tablet/mobile center too.
- Laptop-height viewports (≥1024px wide, ≤1050px tall) **keep their full-screen `100vh` hero** but center the content instead of pinning it to the top. Headline scaling on short screens is retained so the type still fits.
- Tall desktop (>1050px tall) 75vh centered hero is unchanged.

| Viewport | Height | Alignment |
|---|---|---|
| Tall desktop (>1050px tall) | 75vh | centered (unchanged) |
| Laptop / short (≤1050px tall) | 100vh full screen | centered (was top-anchored) |
| Tablet / mobile | 75vh | centered (was top-anchored) |

### 2. How We Build (service process section) — `HowWeBuild.astro`
- Header centered (`text-align: center`); "Our Process" eyebrow uses the design-system `variant="centered"` SectionLabel.

### 3. About page — `Values.astro`, `about.astro`
- Our Values numbers: `.value-card__number` bumped `0.75rem → 0.9375rem` (12px → 15px).
- Our Team section hidden via `<Team visible={false} />` (not deleted — component, markup and Sanity fetch retained; restore with `visible={teamMembers.length > 0}`).

## Verification

Verified in the dev preview (no console errors):
- Service page @ 1280×720 — hero fills the viewport, content vertically centered; How We Build header centered.
- About page — Values numbers compute to 15px; Team section absent from the DOM, page flows Values → Partners & Certifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)