### PR TITLE
Fix CookieYes banner cursor + refresh go-live deployment docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,13 +285,15 @@ await fetch(`https://api.hsforms.com/submissions/v3/integration/submit/${portalI
 });
 ```
 
-### Cloudflare Pages Deployment
+### Cloudflare Workers Deployment
 
-- **Staging:** Push to `main` → auto-deploys to `<project>.pages.dev`
-- **Preview:** PR branches → `<branch>.<project>.pages.dev`
+Hosting is Cloudflare **Workers** (Astro static assets served from the edge + a Worker for SSR/redirects) via `@astrojs/cloudflare` v13+. See [wrangler.toml](wrangler.toml).
+
+- **Staging:** Push to `main` → auto-deploys to the `*.workers.dev` URL
+- **Preview:** PR branches → preview Worker deployment
 - **Manual:** `npm run deploy` / `npm run deploy:preview`
-- **Production:** Custom domain `kpinfo.tech` (to be configured when site goes live)
-- **Rebuild trigger:** Sanity webhook → Cloudflare Pages deploy hook
+- **Production:** Custom domain `kpinfo.tech` (apex) attached to the Worker. `www.kpinfo.tech` 301-redirects to the apex via a Cloudflare Redirect Rule. The codebase hard-codes the apex as the single canonical host — canonical URLs, analytics/consent gating, and the `noindex` fallback all key off `hostname === 'kpinfo.tech'`.
+- **Rebuild trigger:** Sanity webhook → Cloudflare deploy hook
 
 ### Static Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,13 +285,15 @@ await fetch(`https://api.hsforms.com/submissions/v3/integration/submit/${portalI
 });
 ```
 
-### Cloudflare Pages Deployment
+### Cloudflare Workers Deployment
 
-- **Staging:** Push to `main` → auto-deploys to `<project>.pages.dev`
-- **Preview:** PR branches → `<branch>.<project>.pages.dev`
+Hosting is Cloudflare **Workers** (Astro static assets served from the edge + a Worker for SSR/redirects) via `@astrojs/cloudflare` v13+. See [wrangler.toml](wrangler.toml).
+
+- **Staging:** Push to `main` → auto-deploys to the `*.workers.dev` URL
+- **Preview:** PR branches → preview Worker deployment
 - **Manual:** `npm run deploy` / `npm run deploy:preview`
-- **Production:** Custom domain `kpinfo.tech` (to be configured when site goes live)
-- **Rebuild trigger:** Sanity webhook → Cloudflare Pages deploy hook
+- **Production:** Custom domain `kpinfo.tech` (apex) attached to the Worker. `www.kpinfo.tech` 301-redirects to the apex via a Cloudflare Redirect Rule. The codebase hard-codes the apex as the single canonical host — canonical URLs, analytics/consent gating, and the `noindex` fallback all key off `hostname === 'kpinfo.tech'`.
+- **Rebuild trigger:** Sanity webhook → Cloudflare deploy hook
 
 ### Static Files
 

--- a/src/components/effects/CustomCursor.astro
+++ b/src/components/effects/CustomCursor.astro
@@ -24,6 +24,8 @@
 <style>
   .custom-cursor {
     display: none;
+    opacity: 1;
+    transition: opacity 0.2s ease;
   }
 
   /* Only show on non-touch devices with no reduced motion preference */
@@ -38,6 +40,30 @@
 
     :global(a, button, [role="button"], input, textarea, select, label) {
       cursor: none !important;
+    }
+
+    /*
+     * CookieYes consent banner + preference modal are third-party UI injected
+     * with a near-max z-index, so they paint over our custom cursor while the
+     * global `cursor: none` hides the native one — leaving no visible cursor.
+     * Restore the native cursor on any `cky-`-prefixed element, and fade out our
+     * cursor while the banner is hovered (avoids a ghost ring at its edges).
+     * The token-safe `cky-` selectors won't match unrelated classes (`sticky-*`).
+     */
+    :global(:is([class^="cky-"], [class*=" cky-"])),
+    :global(:is([class^="cky-"], [class*=" cky-"]) *) {
+      cursor: auto !important;
+    }
+
+    :global(
+      :is([class^="cky-"], [class*=" cky-"])
+        :is(a, button, [role="button"], label, input)
+    ) {
+      cursor: pointer !important;
+    }
+
+    :global(body:has(:is([class^="cky-"], [class*=" cky-"]):hover)) .custom-cursor {
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
Two unrelated changes, one per commit.

## 1. Fix: native cursor invisible over the CookieYes consent banner
The custom cursor (`src/components/effects/CustomCursor.astro`) forces `cursor: none` globally and renders at `z-index: 10000–10001`, below CookieYes's near-max z-index. Result: while hovering the consent banner / preference modal, the native cursor is suppressed **and** the custom cursor is painted behind the banner — so no cursor is visible at all.

**Fix (CSS only):**
- Restore the native cursor on any `cky-`-prefixed element — `auto` on containers/text, `pointer` on buttons & links.
- Fade out the custom cursor while the banner is hovered via `body:has(…cky-…:hover)`, avoiding a lagging ghost ring at the edges.
- Token-safe selectors (`[class^="cky-"]`, `[class*=" cky-"]`) so lookalikes like `sticky-*` are not matched.

**Verification:** dev server + computed-style checks — injected `.cky-*` elements resolve to `auto`/`pointer`, `.sticky-nav` stays `none`, `:has()` supported, rule compiled & scoped correctly. The real banner is hostname-gated to `kpinfo.tech` so the live `:hover` trigger should get a final visual check on the production domain after deploy.

## 2. Docs: deployment section now reflects Workers + apex-canonical go-live
`CLAUDE.md` / `AGENTS.md` still described the retired Cloudflare **Pages** setup. Updated to the Workers deployment, the apex `kpinfo.tech` custom domain, the `www → apex` redirect, and the single-canonical-host rule the codebase enforces (analytics/consent/`noindex` all key off `hostname === 'kpinfo.tech'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)