### PR TITLE
perf: improve mobile PageSpeed (LCP, fonts, favicon, CLS)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -95,6 +95,8 @@ const socials = [
             <img
               src={logoUrl}
               alt={siteName}
+              width="49"
+              height="80"
               class="footer-logo"
             />
           ) : (

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -116,6 +116,8 @@ const logoUrl = logo
         <img
           src={logoUrl}
           alt={siteName}
+          width="33"
+          height="54"
           style="height: 54px; width: auto;"
           class="object-contain"
         />

--- a/src/components/sections/PageHero.astro
+++ b/src/components/sections/PageHero.astro
@@ -35,6 +35,7 @@ const resolvedImage = image || heroPlaceholder;
       fallbackFormat="jpg"
       quality={80}
       loading="eager"
+      fetchpriority="high"
       class="page-hero__bg-img"
     />
   </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,6 +10,11 @@ import { canonicalUrl, jsonLdGraph, organizationSchema, seoImageUrl, ORG_PHONE, 
 import CustomCursor from '../components/effects/CustomCursor.astro';
 import ScrollProgress from '../components/effects/ScrollProgress.astro';
 import WhatsAppButton from '../components/ui/WhatsAppButton.astro';
+// Above-the-fold font weights, imported so Vite resolves the same hashed URL the
+// bundled @font-face uses — lets us preload them and shorten the CSS→font chain.
+// Hero H1 = Playfair Display 500; nav/body = Outfit 400.
+import playfairDisplay500 from '@fontsource/playfair-display/files/playfair-display-latin-500-normal.woff2?url';
+import outfit400 from '@fontsource/outfit/files/outfit-latin-400-normal.woff2?url';
 
 interface Props {
   title?: string;
@@ -56,9 +61,12 @@ const clarityProjectId = import.meta.env.PUBLIC_CLARITY_ID;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Preload above-the-fold fonts to shorten the render-critical CSS→font chain -->
+    <link rel="preload" href={playfairDisplay500} as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href={outfit400} as="font" type="font/woff2" crossorigin />
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
     <!-- Primary Meta Tags -->
     <title>{fullTitle}</title>


### PR DESCRIPTION
## Summary

Polish pass on mobile PageSpeed Insights. The site already scored **98 / 97 / 96 / 100** (Perf / A11y / Best Practices / SEO), so this targets the few remaining items: LCP, the render-critical font chain, the one console error, and CLS hygiene.

## Changes
- **Hero LCP image → `fetchpriority="high"`** (`PageHero.astro`) — the largest element on mobile; tells the browser to prioritize it. Main lever on the ~2.4s LCP.
- **Preload Playfair 500 + Outfit 400** (`BaseLayout.astro`) — imported via `?url` so the preload `href` byte-matches the bundled `@font-face` URL. Shortens the HTML→CSS→font request chain.
- **Remove broken `/favicon.ico` link** (`BaseLayout.astro`) — it 404'd on every load; the SVG favicon already covers modern browsers and Google. Clears the only console error → Best Practices.
- **Add `width`/`height` to header + footer logos** (`Navigation.astro`, `Footer.astro`) — clears the "unsized images" audit, CLS hygiene.

## Verification
- Production build passes; all four changes confirmed in `dist/client/index.html`.
- Preload font URLs verified **byte-identical** to the CSS `@font-face` URLs — fonts load once, not twice.

## Not included (intentional)
- **Work-card thumbnail resizing** (~193 KiB) — would soften retina images for a lazy, below-the-fold, zero-CWV gain. Wrong trade for a premium-imagery design system.
- **CookieYes button contrast (4.14:1)** — configured in the CookieYes dashboard, not code.
- **Tech-marquee contrast (1.76:1)** — partly intentional (dark brand colors); needs a design call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)