### PR TITLE
fix: load Microsoft Clarity normally instead of CookieYes script-blocking

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,8 +51,12 @@ const jsonLdPayload = jsonLdGraph([organizationSchema(siteSettings), ...jsonLdNo
 // Analytics IDs (public). When unset at build time, the tag block is not
 // rendered at all (no tracking). At runtime the scripts additionally gate on
 // the production hostname so preview / *.workers.dev builds stay clean.
-const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
-const clarityProjectId = import.meta.env.PUBLIC_CLARITY_ID;
+// `.trim()` guards against stray whitespace in a CI/build env var (e.g. a value
+// pasted into the Cloudflare build variables with a trailing space) — that would
+// otherwise produce a broken tag URL / measurement id. A whitespace-only value
+// trims to '' (falsy) and correctly omits the tag block.
+const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID?.trim();
+const clarityProjectId = import.meta.env.PUBLIC_CLARITY_ID?.trim();
 ---
 
 <!doctype html>
@@ -153,9 +157,13 @@ const clarityProjectId = import.meta.env.PUBLIC_CLARITY_ID;
       }
     </script>
 
-    {/* Microsoft Clarity — text/plain + data-cookieyes so CookieYes only runs it after the visitor accepts the Analytics category. */}
+    {/* Microsoft Clarity — loads normally on the production host. Consent is enforced by Clarity's
+        own "Cookie consent" project setting + CookieYes's Clarity Consent API integration, which
+        signals consent to Clarity on accept. Do NOT re-add type="text/plain"/data-cookieyes here:
+        CookieYes script-blocking conflicts with the Consent API integration and leaves the tag
+        permanently un-executed (it never lifts the block), so Clarity records nothing. */}
     {clarityProjectId && (
-      <script type="text/plain" data-cookieyes="cookieyes-analytics" define:vars={{ clarityProjectId }}>
+      <script define:vars={{ clarityProjectId }}>
         if (window.location.hostname === 'kpinfo.tech') {
           (function (c, l, a, r, i, t, y) {
             c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };


### PR DESCRIPTION
## Problem

Microsoft Clarity recorded **no data** in production even after visitors accepted the analytics cookie category. GA4 worked correctly.

## Root cause

Clarity was gated with `type="text/plain"` + `data-cookieyes="cookieyes-analytics"`, relying on CookieYes's script-blocker to activate it on consent. Verified on the live apex (`kpinfo.tech`) with consent granted (`ckyConsent.categories.analytics: true`):

- the Clarity `<script>` **stayed `type="text/plain"`** — CookieYes never lifted the block
- `window.clarity` stayed `undefined`; the `clarity.ms/tag` loader never injected

The CookieYes account is configured for the **Microsoft Clarity Consent API integration**, which expects Clarity to load normally and pushes consent via Clarity's own API. Manual script-blocking conflicts with that, so the tag was left permanently un-executed.

GA4 was unaffected because it uses Google **Consent Mode** (tag always loads; consent toggles behaviour), a different mechanism.

## Fix

- **Load Clarity as a normal `<script>`** (still hostname-gated to `kpinfo.tech`); drop `text/plain` + `data-cookieyes`. Consent is now enforced by Clarity's **"Cookie consent"** project setting + CookieYes's **Clarity Consent API integration**. Inline comment added so it isn't reverted.
- **`.trim()` on `PUBLIC_GA_MEASUREMENT_ID` / `PUBLIC_CLARITY_ID`** — a trailing space pasted into the Cloudflare **build** variable had produced `clarity.ms/tag/pqpi438d1f%20` (broken). Trimming hardens against this; a whitespace-only value now correctly omits the tag block.

## Required follow-ups (not code — dashboard/deploy)

- [ ] Cloudflare → build variable `PUBLIC_CLARITY_ID`: remove the trailing space
- [ ] Microsoft Clarity → Settings → **"Cookie consent": ON** (GDPR-compliant; waits for the consent signal)
- [ ] CookieYes → keep **Clarity Consent API integration ON** (already is)
- [ ] Re-run CookieYes GCM **"Check now"** — the prior "Consent tab empty" / "Default consent not set" errors were stale (from before GA4 was actually deployed)

## Verification

`npm run build` passes; built HTML loads Clarity as a normal script with a clean ID (`pqpi438d1f`, no `text/plain`/`data-cookieyes`). After merge + redeploy, will confirm live that `window.clarity` initializes and a beacon hits `clarity.ms/tag/pqpi438d1f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
