### PR TITLE
[codex] Optimize featured work image delivery

### DIFF
--- a/src/components/sections/FeaturedWork.astro
+++ b/src/components/sections/FeaturedWork.astro
@@ -53,7 +53,9 @@ function getImageUrl(image: any): string | null {
                   alt={caseStudy.title}
                   width={800}
                   height={500}
-                  sizes="(max-width: 768px) 100vw, 50vw"
+                  sizes="(max-width: 768px) calc(100vw - 3rem), (max-width: 1023px) calc((100vw - 5rem) / 2), (max-width: 1440px) calc((100vw - 8rem) / 2), 656px"
+                  widths={[320, 480, 640, 800, 1000, 1200]}
+                  quality={70}
                   class="work-card__image"
                   loading="lazy"
                   fill


### PR DESCRIPTION
## Summary
- Tunes Featured Work card image `sizes` to match the actual card/container width instead of advertising full viewport width on mobile.
- Adds card-specific responsive widths and lowers thumbnail quality to 70 while preserving lazy loading, layout, and aspect ratio.

## Impact
- Reduces overlarge mobile image variant selection for homepage Featured Work cards without changing global SanityPicture behavior or hero images.

## Test Plan
- `npm run build`