### PR TITLE
[codex] Update fallback site metadata

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,11 +38,14 @@ const {
 } = Astro.props;
 
 const siteName = siteSettings?.siteName || 'KP Infotech';
-const pageTitle = title || siteSettings?.defaultSeoTitle || siteName;
+const fallbackSeoTitle = 'KP Infotech — Custom Software, ERP, Automation & AI Solutions';
+const fallbackSeoDescription =
+  'KP Infotech helps growing B2B teams replace manual workflows, spreadsheets, and disconnected tools with custom software, Odoo ERP, automation, AI agents, and cloud infrastructure.';
+const pageTitle = title || siteSettings?.defaultSeoTitle || fallbackSeoTitle;
 const fullTitle = pageTitle === siteName || pageTitle.includes(siteName)
   ? pageTitle
   : `${pageTitle} — ${siteName}`;
-const metaDescription = description || siteSettings?.defaultSeoDescription || 'Premium Design and Technology studio crafting digital experiences that elevate brands and drive measurable business growth.';
+const metaDescription = description || siteSettings?.defaultSeoDescription || fallbackSeoDescription;
 const canonical = canonicalUrl(canonicalURL || Astro.url.href);
 const resolvedOgImage = seoImageUrl(ogImage, siteSettings?.defaultOgImage, defaultOgFallback.src);
 const jsonLdNodes = Array.isArray(jsonLd) ? jsonLd : [jsonLd];


### PR DESCRIPTION
## Summary

- Updates only the hard-coded fallback site title and description in src/layouts/BaseLayout.astro.
- Keeps Sanity production defaults as the normal metadata source; these strings are used only when page props and Sanity site defaults are absent.
- Leaves canonical, robots/noindex, OG/Twitter generation, schema, routing, redirects, Sanity queries, sitemap behavior, slugs, and page copy unchanged.

## Validation

- npm run build passed.

## Notes

No Sanity writes were performed. No metadata batch was rerun. No redirect or content files are included in this PR.