### PR TITLE
[codex] Add P0 insight content drafts

### DIFF
--- a/docs/seo-migration/p0-content-drafts/README.md
+++ b/docs/seo-migration/p0-content-drafts/README.md
@@ -1,0 +1,23 @@
+# P0 Content Drafts
+
+Review-only drafts for recreating high-value legacy informational URLs as future `/insights/` articles.
+
+These files do not create Sanity documents, publish posts, change redirects, update sitemap output, modify schema, or change production page behavior. They are drafting artifacts for content review before any Sanity or redirect implementation work.
+
+## Drafts
+
+| Legacy URL | Proposed insight URL | Current redirect target | Target pillar |
+|---|---|---|---|
+| `/what-is-customised-software/` | `/insights/what-is-custom-software/` | `/services/custom-software-development/` | Custom Software Development |
+| `/business-process-automation-tools/` | `/insights/business-process-automation-tools/` | `/services/business-automation/` | Business Automation |
+| `/business-process-improvement-methods/` | `/insights/business-process-improvement-methods/` | `/services/business-automation/` | Business Automation |
+| `/how-to-choose-erp-system/` | `/insights/how-to-choose-erp-system/` | `/services/erp-software/` | ERP & Odoo Solutions |
+| `/on-premise-vs-cloud-erp/` | `/insights/on-premise-vs-cloud-erp/` | `/services/erp-software/` | ERP & Odoo Solutions / Cloud & DevOps |
+| `/best-practices-for-devops/` | `/insights/devops-best-practices/` | `/services/cloud-devops/` | Cloud & DevOps |
+
+## Review Notes
+
+- Treat every draft as unpublished Sanity `blogPost` content.
+- FAQ sections are candidates for FAQ schema only if the questions and answers are displayed on the published page.
+- Related P0 links marked `future after publish` should not be added to a live Sanity body until the linked article exists.
+- Future redirect changes should update the original Worker redirect source directly. Do not create source -> service -> insight chains.

--- a/docs/seo-migration/p0-content-drafts/business-process-automation-tools.md
+++ b/docs/seo-migration/p0-content-drafts/business-process-automation-tools.md
@@ -1,0 +1,147 @@
+# Business Process Automation Tools: Types, Use Cases, and Selection Guide
+
+## Draft Metadata
+
+| Field | Value |
+|---|---|
+| Proposed Sanity title | Business Process Automation Tools: Types, Use Cases, and Selection Guide |
+| Proposed slug | `/insights/business-process-automation-tools/` |
+| Legacy URL | `/business-process-automation-tools/` |
+| Current redirect target | `/services/business-automation/` |
+| Recommended future redirect target | `/insights/business-process-automation-tools/` |
+| Target service pillar | Business Automation |
+| Primary search intent | Help operations leaders understand categories of business process automation tools and choose the right approach for their workflows. |
+| Target audience | Operations managers, founders, finance/admin leaders, and department heads replacing manual approvals, spreadsheets, and repetitive task handoffs. |
+| seoTitle | Business Process Automation Tools: Types & Selection Guide |
+| seoDescription | Compare business process automation tools by use case, workflow complexity, integrations, approvals, reporting, AI fit, and long-term operations needs. |
+| Excerpt | Business process automation tools help teams reduce repetitive work, route approvals, connect systems, and improve visibility. This guide explains the main tool types and how to choose. |
+| Category recommendation | `automation-ai` |
+
+## Internal Links To Include
+
+| Link | Status | Placement |
+|---|---|---|
+| `/services/business-automation/` | Existing service page | "How KP Infotech helps" and selection framework |
+| `/services/ai-automation-agents/` | Existing service page | AI automation section |
+| `/services/custom-software-development/` | Existing service page | Custom workflow software section |
+| `/insights/business-process-improvement-methods/` | Future after publish | Related reading after both P0 drafts are live |
+| `/insights/what-is-custom-software/` | Future after publish | Related reading where custom build is discussed |
+
+## FAQ Questions
+
+- What are business process automation tools?
+- What types of business processes can be automated?
+- How do I choose a business process automation tool?
+- When is a custom automation system better than a no-code tool?
+- Can AI agents be part of business process automation?
+- What should be automated first?
+
+## Redirect-Evolution Note
+
+Yes, the legacy URL should eventually change from the current service redirect to this recreated insight article after review, publishing, indexing, and verification.
+
+- Current redirect: `/business-process-automation-tools/` -> `/services/business-automation/`
+- Future direct redirect: `/business-process-automation-tools/` -> `/insights/business-process-automation-tools/`
+- Warning: update the original Worker redirect source directly. Do not create a `/business-process-automation-tools/` -> `/services/business-automation/` -> `/insights/business-process-automation-tools/` chain.
+
+## Full Article Draft
+
+## What are business process automation tools?
+
+Business process automation tools are systems that reduce manual work by moving tasks, data, approvals, notifications, documents, and reports through a defined workflow. They help teams replace spreadsheet tracking, repeated copy-paste work, email follow-ups, and disconnected tool handoffs with a more reliable operating process.
+
+For growing B2B companies, automation is most useful when a process repeats often, involves multiple people, depends on status visibility, or requires data to move between systems such as ERP, CRM, accounting, inventory, support, or cloud applications.
+
+## Main types of business process automation tools
+
+Different automation tools solve different problems. The right choice depends on workflow complexity and how much control the business needs.
+
+| Tool type | Best fit | Watch-outs |
+|---|---|---|
+| Workflow automation platforms | Approvals, routing, notifications, task handoffs | Can become hard to manage if many exceptions appear |
+| Integration platforms | Moving data between SaaS tools and databases | May not handle custom business logic well |
+| No-code and low-code tools | Fast internal forms, trackers, and simple workflows | Governance, permissions, and scale need attention |
+| ERP workflow tools | Sales, purchasing, inventory, accounting, manufacturing, HR | Works best when ERP data is clean and processes are defined |
+| RPA tools | Repetitive screen-based tasks in older systems | Can be brittle if user interfaces change |
+| Custom automation systems | Unique workflows, portals, dashboards, and complex integrations | Requires discovery, build, maintenance, and ownership |
+| AI automation agents | Document processing, triage, internal assistants, summarization, routing | Needs guardrails, review points, and clear success criteria |
+
+No single category is best for every company. Many mature automation setups combine ERP, integrations, custom software, and AI assistance.
+
+## Processes that are good candidates for automation
+
+Start with workflows that are repeated, rules-based, and painful enough to justify change.
+
+Common examples include:
+
+- Purchase approvals and vendor onboarding
+- Lead routing, CRM updates, and follow-up reminders
+- Invoice intake, document review, and exception routing
+- Inventory alerts, reorder requests, and stock movement visibility
+- Production or service request tracking
+- Employee onboarding checklists and access requests
+- Customer support triage and status notifications
+- Management dashboards that refresh from multiple systems
+
+The goal is not to automate every step. The goal is to remove low-value manual coordination while keeping human judgment where it matters.
+
+## How to choose the right automation tool
+
+Use this decision framework before selecting software:
+
+1. Define the process outcome. What should happen faster, more accurately, or with better visibility?
+2. Map the current workflow. Include triggers, inputs, decision points, exceptions, handoffs, and reporting needs.
+3. List required systems. Identify ERP, CRM, accounting, spreadsheets, databases, forms, email, chat, and APIs.
+4. Separate rules from judgment. Rules can be automated; judgment may need approval screens or human review.
+5. Check ownership. Decide who maintains the workflow when the business process changes.
+6. Start with one workflow. Prove value before expanding automation across departments.
+
+If the process is simple and uses common SaaS tools, an integration platform or low-code workflow may be enough. If the workflow touches core operations, ERP data, custom approval rules, dashboards, or role-based portals, custom automation may be the better long-term choice.
+
+## Where AI agents fit
+
+AI agents can support automation when the work involves unstructured text, documents, classification, search, or recommendations. Examples include reading supplier documents, summarizing support cases, preparing draft responses, identifying missing form fields, or routing requests to the right team.
+
+AI should not be added just because it is available. It needs clear boundaries:
+
+- What can the agent decide?
+- What needs human approval?
+- What data can it access?
+- How are mistakes reviewed?
+- What logs or audit trail are required?
+
+For many companies, the strongest AI automation projects combine deterministic workflow rules with AI assistance for the messy parts.
+
+## How KP Infotech helps
+
+KP Infotech provides [business automation services](/services/business-automation/) for teams that want to replace spreadsheet-driven work, manual approvals, repeated admin tasks, and disconnected tools with practical operating systems.
+
+Depending on the workflow, that may involve ERP and Odoo configuration, custom internal tools, integrations, dashboards, approval flows, notifications, and [AI automation agents](/services/ai-automation-agents/) with human review points. If a workflow needs a dedicated application or portal, KP Infotech can also build it through [custom software development](/services/custom-software-development/).
+
+The focus is on making the process work in the real business environment, not only connecting tools on paper.
+
+## FAQs
+
+### What are business process automation tools?
+
+They are tools that automate repeated business workflows such as approvals, task routing, data entry, notifications, document handling, reporting, and system integrations.
+
+### What types of business processes can be automated?
+
+Processes such as purchase approvals, lead routing, invoice handling, inventory alerts, onboarding, support triage, production tracking, and management reporting are common automation candidates.
+
+### How do I choose a business process automation tool?
+
+Start by mapping the workflow, identifying required systems, listing exceptions, and deciding who will maintain the process. Then choose the simplest tool category that can handle the workflow reliably.
+
+### When is a custom automation system better than a no-code tool?
+
+Custom automation is usually better when the workflow is central to operations, has complex business rules, needs custom dashboards or portals, or must connect deeply with ERP, CRM, databases, or legacy systems.
+
+### Can AI agents be part of business process automation?
+
+Yes. AI agents can help with document processing, request triage, internal search, summaries, and recommendations, but they should include guardrails and human review for important decisions.
+
+### What should be automated first?
+
+Start with a workflow that repeats often, creates visible delays, has clear rules, and has a measurable business owner. Avoid starting with a vague company-wide automation program.

--- a/docs/seo-migration/p0-content-drafts/business-process-improvement-methods.md
+++ b/docs/seo-migration/p0-content-drafts/business-process-improvement-methods.md
@@ -1,0 +1,154 @@
+# Business Process Improvement Methods for Growing Companies
+
+## Draft Metadata
+
+| Field | Value |
+|---|---|
+| Proposed Sanity title | Business Process Improvement Methods for Growing Companies |
+| Proposed slug | `/insights/business-process-improvement-methods/` |
+| Legacy URL | `/business-process-improvement-methods/` |
+| Current redirect target | `/services/business-automation/` |
+| Recommended future redirect target | `/insights/business-process-improvement-methods/` |
+| Target service pillar | Business Automation |
+| Primary search intent | Explain practical business process improvement methods and show how growing companies can diagnose, simplify, automate, and measure workflows. |
+| Target audience | Business owners, operations leaders, department managers, and transformation teams improving workflows before or during automation. |
+| seoTitle | Business Process Improvement Methods for Growing Teams |
+| seoDescription | Learn practical business process improvement methods for reducing manual work, improving visibility, simplifying workflows, and preparing for automation. |
+| Excerpt | Business process improvement helps growing companies remove bottlenecks before they automate. This guide covers practical methods, examples, and a process audit checklist. |
+| Category recommendation | `automation-ai` |
+
+## Internal Links To Include
+
+| Link | Status | Placement |
+|---|---|---|
+| `/services/business-automation/` | Existing service page | "How KP Infotech helps" and automation-readiness sections |
+| `/services/ai-automation-agents/` | Existing service page | AI-supported improvement examples |
+| `/services/erp-software/` | Existing service page | ERP process standardization section |
+| `/insights/business-process-automation-tools/` | Future after publish | Related reading after both P0 drafts are live |
+
+## FAQ Questions
+
+- What is business process improvement?
+- What are common business process improvement methods?
+- How do you improve a process before automating it?
+- What is the difference between process improvement and process automation?
+- Which business processes should be improved first?
+- How can KP Infotech support process improvement?
+
+## Redirect-Evolution Note
+
+Yes, the legacy URL should eventually change from the current service redirect to this recreated insight article after review, publishing, indexing, and verification.
+
+- Current redirect: `/business-process-improvement-methods/` -> `/services/business-automation/`
+- Future direct redirect: `/business-process-improvement-methods/` -> `/insights/business-process-improvement-methods/`
+- Warning: update the original Worker redirect source directly. Do not create a `/business-process-improvement-methods/` -> `/services/business-automation/` -> `/insights/business-process-improvement-methods/` chain.
+
+## Full Article Draft
+
+## What is business process improvement?
+
+Business process improvement is the practice of analyzing how work currently gets done, finding delays or errors, simplifying unnecessary steps, and improving the workflow so teams can operate with better speed, accuracy, and visibility.
+
+For growing B2B companies, process improvement often starts when spreadsheet tracking, manual approvals, repeated status calls, or disconnected tools make daily operations harder to control. Improvement does not always mean immediate automation. First, the process needs to be understood and simplified. Then automation, ERP workflows, dashboards, integrations, or AI agents can support it.
+
+## Why process improvement matters before automation
+
+Automation makes a workflow faster, but it does not automatically make the workflow better. If the process is unclear, duplicated, or poorly owned, automation can simply move confusion faster.
+
+Before automating, teams should ask:
+
+- What triggers the process?
+- Who owns each step?
+- What information is required?
+- Where do delays happen?
+- Which decisions follow rules?
+- Which decisions require judgment?
+- What exceptions happen often?
+- What should managers be able to see in real time?
+
+These answers help the team improve the process before choosing a tool.
+
+## Practical business process improvement methods
+
+| Method | What it helps with | Example |
+|---|---|---|
+| Process mapping | Makes steps, owners, inputs, and outputs visible | Map purchase approval from request to payment |
+| Bottleneck analysis | Finds where work waits, repeats, or gets blocked | Identify approval queues that delay procurement |
+| Standard operating procedure review | Removes unclear or inconsistent steps | Standardize how support tickets are categorized |
+| Waste reduction | Removes duplicate entry, unnecessary approvals, and manual status checks | Stop entering the same order data in two systems |
+| Root cause analysis | Finds why errors repeat instead of fixing symptoms | Trace inventory mismatch back to delayed stock updates |
+| KPI and dashboard design | Defines what should be measured | Track cycle time, open approvals, overdue tasks, and exceptions |
+| Automation readiness review | Decides what can be automated safely | Separate rule-based routing from manager approval decisions |
+
+Most teams do not need a formal methodology-heavy program to begin. They need a clear map, business ownership, and a prioritized list of friction points.
+
+## A process audit checklist
+
+Use this checklist to identify improvement opportunities:
+
+- The same data is entered more than once.
+- Work is tracked in spreadsheets that only one person understands.
+- Team members ask for status updates in chat or email.
+- Approvals are delayed because the next owner is unclear.
+- Reports are prepared manually at the end of the week or month.
+- Exceptions are common but undocumented.
+- Customers, vendors, or internal teams cannot see request status.
+- Managers do not have a live view of workload, delays, or risk.
+- ERP, CRM, accounting, and operational tools do not share key data.
+
+If several of these are true, the process is a candidate for improvement and possibly automation.
+
+## Process improvement examples
+
+In finance, improvement may mean standardizing invoice intake, approval rules, exception handling, and payment status reporting before automating reminders and ERP updates.
+
+In operations, it may mean replacing a spreadsheet-based production tracker with a workflow that captures status, dependencies, delays, quality notes, and dashboard views.
+
+In sales or service, it may mean defining lead assignment rules, follow-up steps, customer communication points, and CRM updates before automating routing and reminders.
+
+In inventory-heavy businesses, it may mean connecting reorder triggers, purchase requests, supplier updates, stock movements, and exception dashboards through ERP or custom tools.
+
+## Process improvement vs process automation
+
+Process improvement decides how the workflow should work. Process automation helps the workflow run with less manual effort.
+
+| Question | Process improvement | Process automation |
+|---|---|---|
+| Main purpose | Make the workflow clearer and better | Reduce manual execution |
+| Typical output | Process map, simplified steps, ownership, KPIs | Workflow rules, integrations, dashboards, notifications |
+| Best timing | Before tool selection or rebuild | After the workflow is defined |
+| Risk if skipped | Automating confusion | Building the wrong workflow faster |
+
+The two should work together. A strong automation project usually begins with a process improvement exercise.
+
+## How KP Infotech helps
+
+KP Infotech helps growing teams turn operational friction into practical systems through [business automation](/services/business-automation/), ERP and Odoo workflows, custom internal tools, dashboards, integrations, and [AI automation agents](/services/ai-automation-agents/).
+
+The work starts by understanding the current process: who does the work, where data lives, what repeats, where approvals slow down, and what visibility leaders need. From there, KP Infotech can help simplify the workflow and build the right system around it. For ERP-heavy processes, [Odoo ERP implementation and customization](/services/erp-software/) can become part of the improvement path.
+
+## FAQs
+
+### What is business process improvement?
+
+Business process improvement is the practice of reviewing and changing a workflow so it becomes clearer, faster, more accurate, and easier to measure.
+
+### What are common business process improvement methods?
+
+Common methods include process mapping, bottleneck analysis, root cause analysis, SOP review, waste reduction, KPI design, and automation-readiness assessment.
+
+### How do you improve a process before automating it?
+
+Map the workflow, identify owners and handoffs, remove duplicate steps, define rules and exceptions, decide what should be measured, and then choose automation only for the parts that are stable enough.
+
+### What is the difference between process improvement and process automation?
+
+Process improvement decides what the workflow should be. Process automation uses tools, rules, integrations, and notifications to reduce manual work inside that workflow.
+
+### Which business processes should be improved first?
+
+Start with processes that repeat often, affect customers or revenue, create manual rework, delay decisions, or prevent leaders from seeing operational status.
+
+### How can KP Infotech support process improvement?
+
+KP Infotech can help map workflows, identify automation opportunities, connect systems, configure ERP workflows, build dashboards, and develop custom tools around the improved process.

--- a/docs/seo-migration/p0-content-drafts/devops-best-practices.md
+++ b/docs/seo-migration/p0-content-drafts/devops-best-practices.md
@@ -1,0 +1,179 @@
+# DevOps Best Practices for Reliable Business Applications
+
+## Draft Metadata
+
+| Field | Value |
+|---|---|
+| Proposed Sanity title | DevOps Best Practices for Reliable Business Applications |
+| Proposed slug | `/insights/devops-best-practices/` |
+| Legacy URL | `/best-practices-for-devops/` |
+| Current redirect target | `/services/cloud-devops/` |
+| Recommended future redirect target | `/insights/devops-best-practices/` |
+| Target service pillar | Cloud & DevOps |
+| Primary search intent | Explain practical DevOps practices for reliable deployments, infrastructure, monitoring, rollback, security, and maintainable business systems. |
+| Target audience | Founders, engineering leads, IT owners, operations leaders, and teams running business applications, portals, ERP-connected systems, or SaaS platforms. |
+| seoTitle | DevOps Best Practices for Reliable Business Apps |
+| seoDescription | Learn DevOps best practices for CI/CD, infrastructure, monitoring, rollback, backups, security, and operational reliability in business applications. |
+| Excerpt | DevOps best practices help teams ship changes safely and keep business applications reliable. This guide covers CI/CD, monitoring, rollback, backups, security, and maturity planning. |
+| Category recommendation | `cloud-devops` |
+
+## Internal Links To Include
+
+| Link | Status | Placement |
+|---|---|---|
+| `/services/cloud-devops/` | Existing service page | "How KP Infotech helps" and infrastructure sections |
+| `/services/custom-software-development/` | Existing service page | Application delivery context |
+| `/insights/scalable-system-architecture/` | Existing insight page | Related architecture reading |
+| `/insights/cloud-deployment-models-diagram/` | Existing insight page | Cloud deployment model reading |
+| `/insights/on-premise-vs-cloud-erp/` | Future after publish | Related reading for ERP infrastructure decisions |
+
+## FAQ Questions
+
+- What are DevOps best practices?
+- Why does DevOps matter for business applications?
+- What should a CI/CD pipeline include?
+- How do monitoring and rollback reduce operational risk?
+- How does DevOps support custom software and ERP systems?
+- What is the first DevOps improvement a team should make?
+
+## Redirect-Evolution Note
+
+Yes, the legacy URL should eventually change from the current service redirect to this recreated insight article after review, publishing, indexing, and verification.
+
+- Current redirect: `/best-practices-for-devops/` -> `/services/cloud-devops/`
+- Future direct redirect: `/best-practices-for-devops/` -> `/insights/devops-best-practices/`
+- Warning: update the original Worker redirect source directly. Do not create a `/best-practices-for-devops/` -> `/services/cloud-devops/` -> `/insights/devops-best-practices/` chain.
+
+## Full Article Draft
+
+## What are DevOps best practices?
+
+DevOps best practices are the engineering and operations habits that help teams build, deploy, monitor, secure, and recover business applications reliably. They connect software delivery with infrastructure operations so changes can move to production without avoidable risk.
+
+For growing businesses, DevOps is not only for large engineering teams. It matters when a customer portal, ERP-connected workflow, internal dashboard, SaaS product, automation system, or mobile app becomes important to daily operations.
+
+## Why DevOps matters for business systems
+
+When business applications are deployed manually, monitored casually, or backed up inconsistently, small changes can create operational risk. DevOps practices reduce that risk by making delivery repeatable and observable.
+
+Good DevOps helps teams:
+
+- Deploy changes consistently
+- Find production issues sooner
+- Roll back safely when needed
+- Protect environments and secrets
+- Keep backups and recovery plans testable
+- Scale infrastructure as usage grows
+- Improve collaboration between developers, IT, and business owners
+
+The goal is not tool complexity. The goal is reliable business operations.
+
+## Core DevOps best practices
+
+| Practice | Why it matters |
+|---|---|
+| Version control | Keeps code, infrastructure, and changes traceable |
+| CI/CD pipelines | Builds, tests, and deploys changes in a repeatable way |
+| Environment separation | Keeps development, staging, and production changes controlled |
+| Infrastructure as code | Makes cloud resources easier to review, reproduce, and recover |
+| Secrets management | Protects API keys, database credentials, and environment variables |
+| Automated tests | Reduces avoidable regressions before deployment |
+| Monitoring and alerts | Shows errors, latency, uptime, and resource pressure |
+| Logging | Helps teams diagnose failures with useful context |
+| Backup and recovery plans | Makes data loss and outage recovery less improvised |
+| Rollback strategy | Lets teams return to a stable version when a release fails |
+| Access control | Limits production access to the right people and systems |
+
+Teams do not need to adopt every practice at once. They should prioritize practices around the highest operational risk.
+
+## What a practical CI/CD pipeline should include
+
+A useful CI/CD pipeline should make releases repeatable and reviewable.
+
+For a typical business application, it may include:
+
+- Install dependencies
+- Run linting or formatting checks where available
+- Run unit and integration tests
+- Build the application
+- Validate required environment variables
+- Deploy to staging or preview
+- Run smoke checks
+- Promote to production with approval when needed
+- Keep deployment logs and release history
+
+For ERP-connected systems, dashboards, and automation workflows, pipeline checks should also consider database migrations, API compatibility, queue workers, scheduled tasks, and integration credentials.
+
+## Monitoring, rollback, and recovery
+
+DevOps is incomplete without production visibility.
+
+Monitoring should answer:
+
+- Is the application up?
+- Are users seeing errors?
+- Are APIs slow?
+- Are background jobs stuck?
+- Are database or queue resources under pressure?
+- Did the latest release change error rates?
+
+Rollback planning should answer:
+
+- How do we return to the previous stable version?
+- What happens if a database migration fails?
+- Are backups recent and tested?
+- Who decides whether to roll back?
+- What is communicated to users or internal teams?
+
+These decisions should be made before an incident, not during one.
+
+## DevOps maturity checklist
+
+Use this checklist to decide what to improve next:
+
+- Code is stored in version control.
+- Production deployments are not done manually from one person's machine.
+- Staging or preview environments exist.
+- Tests run before production deployment.
+- Environment variables and secrets are not hard-coded.
+- Logs are available for production issues.
+- Uptime, errors, and performance are monitored.
+- Backups are automated and recovery has been tested.
+- Access to production systems is limited and auditable.
+- There is a documented rollback process.
+
+If several of these are missing, start with deployment repeatability, monitoring, and backups.
+
+## How KP Infotech helps
+
+KP Infotech provides [Cloud & DevOps services](/services/cloud-devops/) for businesses that need reliable infrastructure, CI/CD pipelines, monitoring, backups, hosting, security controls, and cost-aware cloud operations.
+
+This work often supports [custom software development](/services/custom-software-development/), ERP and Odoo systems, internal dashboards, portals, APIs, and automation workflows. KP Infotech can help design deployment processes, configure cloud environments, improve release safety, and support business applications after launch.
+
+For architecture planning, see the [scalable system architecture guide](/insights/scalable-system-architecture/) and the [cloud deployment models guide](/insights/cloud-deployment-models-diagram/).
+
+## FAQs
+
+### What are DevOps best practices?
+
+DevOps best practices include version control, CI/CD, testing, environment separation, infrastructure as code, monitoring, logging, backups, secrets management, access control, and rollback planning.
+
+### Why does DevOps matter for business applications?
+
+Business applications often support customers, employees, finance, operations, or reporting. DevOps reduces deployment risk and improves reliability when those systems become operationally important.
+
+### What should a CI/CD pipeline include?
+
+A CI/CD pipeline should install dependencies, run checks, build the application, validate configuration, deploy to staging or preview, support production promotion, and keep a release trail.
+
+### How do monitoring and rollback reduce operational risk?
+
+Monitoring helps teams detect issues quickly. Rollback planning gives the team a clear way to return to a stable version when a release causes problems.
+
+### How does DevOps support custom software and ERP systems?
+
+DevOps supports custom software and ERP-connected systems by making deployments repeatable, integrations observable, backups reliable, and production operations easier to maintain.
+
+### What is the first DevOps improvement a team should make?
+
+Start with the highest current risk. For many teams, that means moving away from manual production deployments, adding basic monitoring, and confirming backups and rollback steps.

--- a/docs/seo-migration/p0-content-drafts/how-to-choose-erp-system.md
+++ b/docs/seo-migration/p0-content-drafts/how-to-choose-erp-system.md
@@ -1,0 +1,165 @@
+# How to Choose an ERP System: Requirements, Costs, and Evaluation Checklist
+
+## Draft Metadata
+
+| Field | Value |
+|---|---|
+| Proposed Sanity title | How to Choose an ERP System: Requirements, Costs, and Evaluation Checklist |
+| Proposed slug | `/insights/how-to-choose-erp-system/` |
+| Legacy URL | `/how-to-choose-erp-system/` |
+| Current redirect target | `/services/erp-software/` |
+| Recommended future redirect target | `/insights/how-to-choose-erp-system/` |
+| Target service pillar | ERP & Odoo Solutions |
+| Primary search intent | Guide ERP buyers through requirements, module fit, deployment, implementation cost, vendor evaluation, and rollout risk. |
+| Target audience | Business owners, finance leaders, operations heads, IT teams, and ERP selection committees replacing spreadsheets or disconnected systems. |
+| seoTitle | How to Choose an ERP System: Evaluation Checklist |
+| seoDescription | Learn how to choose an ERP system by mapping requirements, modules, integrations, costs, deployment options, vendor fit, and implementation readiness. |
+| Excerpt | Choosing an ERP system is an operations decision, not only a software purchase. This guide explains how to evaluate requirements, costs, modules, vendors, and rollout risk. |
+| Category recommendation | `erp-business-systems` |
+
+## Internal Links To Include
+
+| Link | Status | Placement |
+|---|---|---|
+| `/services/erp-software/` | Existing service page | "How KP Infotech helps" and ERP readiness sections |
+| `/insights/odoo-erp-complete-guide/` | Existing insight page | Odoo-specific related reading |
+| `/services/business-automation/` | Existing service page | Workflow and process readiness section |
+| `/insights/on-premise-vs-cloud-erp/` | Future after publish | Related reading after both P0 drafts are live |
+
+## FAQ Questions
+
+- How do I choose the right ERP system?
+- What requirements should be documented before ERP selection?
+- Is Odoo a good ERP option for growing businesses?
+- What are the hidden costs of ERP implementation?
+- Should I choose cloud ERP or on-premise ERP?
+- What should I ask an ERP implementation partner?
+
+## Redirect-Evolution Note
+
+Yes, the legacy URL should eventually change from the current service redirect to this recreated insight article after review, publishing, indexing, and verification.
+
+- Current redirect: `/how-to-choose-erp-system/` -> `/services/erp-software/`
+- Future direct redirect: `/how-to-choose-erp-system/` -> `/insights/how-to-choose-erp-system/`
+- Warning: update the original Worker redirect source directly. Do not create a `/how-to-choose-erp-system/` -> `/services/erp-software/` -> `/insights/how-to-choose-erp-system/` chain.
+
+## Full Article Draft
+
+## How do you choose an ERP system?
+
+Choose an ERP system by mapping your business requirements first, then evaluating software fit, module coverage, implementation effort, integrations, reporting needs, deployment model, support model, and total cost. ERP selection should start with operations, not with a vendor demo.
+
+For growing companies, ERP usually becomes urgent when finance, sales, purchase, inventory, manufacturing, HR, and operations depend on spreadsheets or disconnected tools. The goal is to create one reliable operating backbone that supports daily work and management visibility.
+
+## Step 1: Define the business problem
+
+ERP projects fail when the goal is vague. Start by writing the operational problems the ERP must solve.
+
+Examples:
+
+- Inventory numbers are unreliable across warehouses or sales channels.
+- Purchase approvals and vendor follow-ups are handled manually.
+- Finance closes reports late because data comes from multiple spreadsheets.
+- Sales, stock, billing, and dispatch teams do not share the same status view.
+- Manufacturing or service teams cannot track work-in-progress clearly.
+- Management cannot see cash flow, order status, stock, or delivery risk in one place.
+
+Clear problems lead to clearer ERP requirements.
+
+## Step 2: Map required ERP modules
+
+Most ERP evaluations should begin with module fit.
+
+| Business area | ERP capabilities to review |
+|---|---|
+| Sales and CRM | Leads, quotations, orders, customer history, follow-ups |
+| Purchasing | Supplier records, purchase requests, approvals, purchase orders |
+| Inventory | Stock levels, warehouses, transfers, batches, reorder rules |
+| Accounting and finance | Invoices, payments, taxes, reporting, reconciliation |
+| Manufacturing or operations | Bills of materials, work orders, production status, quality steps |
+| HR and payroll | Employee data, attendance, leave, payroll integrations |
+| Reporting | Dashboards, KPIs, exception reports, role-based visibility |
+| Integrations | Ecommerce, CRM, payment gateways, shipping, spreadsheets, APIs |
+
+Do not buy modules because they sound useful. Prioritize modules that support actual operating needs.
+
+## Step 3: Compare ERP fit, not only features
+
+A feature checklist is useful, but fit matters more. A system may technically have a feature and still be difficult for your team to use.
+
+Evaluate:
+
+- Workflow fit: Does the ERP match how the business should operate?
+- Configuration flexibility: Can fields, approvals, roles, and reports be adjusted?
+- Integration needs: Can it connect with existing systems?
+- Data model: Can current data be migrated cleanly?
+- User experience: Will teams use it daily without workarounds?
+- Reporting: Can managers see the right KPIs and exceptions?
+- Partner capability: Can the implementation team handle process design, customization, migration, training, and support?
+
+Odoo is often considered by growing businesses because it offers broad modules and customization flexibility. For a deeper Odoo-specific overview, see the [Odoo ERP guide](/insights/odoo-erp-complete-guide/).
+
+## Step 4: Understand ERP costs
+
+ERP cost includes more than license fees.
+
+Review these cost areas:
+
+- Software licensing or subscription
+- Implementation and configuration
+- Data cleanup and migration
+- Customization and development
+- Integrations with existing systems
+- Reports and dashboards
+- Training and change management
+- Hosting, cloud infrastructure, backups, and security
+- Ongoing support and improvements
+
+A lower software subscription can still become expensive if the system needs heavy customization or if the implementation partner does not understand the process.
+
+## ERP evaluation checklist
+
+Use this checklist during shortlisting:
+
+- Have we mapped current workflows and pain points?
+- Have department owners approved requirements?
+- Are must-have and nice-to-have features separated?
+- Do we understand required integrations?
+- Is historical data ready to migrate?
+- Can the ERP support role-based access and approvals?
+- Can dashboards replace manual reporting?
+- Does the implementation partner understand our industry workflows?
+- Is there a rollout plan for training and adoption?
+- Do we know the cost of support after go-live?
+
+## How KP Infotech helps
+
+KP Infotech provides [Odoo ERP implementation and customization](/services/erp-software/) for growing businesses that need connected operations across CRM, sales, purchase, inventory, accounting, manufacturing, HR, and reporting.
+
+The work can include requirements mapping, module selection, Odoo configuration, custom workflows, integrations, data migration, dashboards, user training, cloud hosting, and post-launch support. If the ERP project also requires process redesign or workflow automation outside ERP, KP Infotech can connect it with [business automation](/services/business-automation/).
+
+## FAQs
+
+### How do I choose the right ERP system?
+
+Start with your operating requirements, not the software demo. Map workflows, required modules, integrations, reporting needs, users, data migration, and support expectations before comparing vendors.
+
+### What requirements should be documented before ERP selection?
+
+Document departments, workflows, approvals, reports, user roles, integrations, data sources, compliance needs, and pain points that the ERP must solve.
+
+### Is Odoo a good ERP option for growing businesses?
+
+Odoo can be a strong option for growing businesses that need modular ERP capabilities and customization flexibility. Fit depends on process requirements, implementation quality, data readiness, and support needs.
+
+### What are the hidden costs of ERP implementation?
+
+Hidden costs often include data cleanup, migration, custom reports, integrations, workflow changes, training, cloud hosting, and support after go-live.
+
+### Should I choose cloud ERP or on-premise ERP?
+
+The right deployment model depends on control, compliance, internet reliability, internal IT capacity, customization needs, and long-term maintenance expectations.
+
+### What should I ask an ERP implementation partner?
+
+Ask how they handle requirements, data migration, customization, integrations, training, change requests, support, cloud infrastructure, and post-launch improvements.

--- a/docs/seo-migration/p0-content-drafts/on-premise-vs-cloud-erp.md
+++ b/docs/seo-migration/p0-content-drafts/on-premise-vs-cloud-erp.md
@@ -1,0 +1,152 @@
+# On-Premise vs Cloud ERP: Differences, Costs, Security, and Fit
+
+## Draft Metadata
+
+| Field | Value |
+|---|---|
+| Proposed Sanity title | On-Premise vs Cloud ERP: Differences, Costs, Security, and Fit |
+| Proposed slug | `/insights/on-premise-vs-cloud-erp/` |
+| Legacy URL | `/on-premise-vs-cloud-erp/` |
+| Current redirect target | `/services/erp-software/` |
+| Recommended future redirect target | `/insights/on-premise-vs-cloud-erp/` |
+| Target service pillar | ERP & Odoo Solutions / Cloud & DevOps |
+| Primary search intent | Compare on-premise ERP and cloud ERP across control, cost, security, maintenance, access, scalability, and operational fit. |
+| Target audience | ERP buyers, IT leaders, operations heads, finance teams, and business owners choosing an ERP deployment model. |
+| seoTitle | On-Premise vs Cloud ERP: Key Differences & Fit |
+| seoDescription | Compare on-premise ERP and cloud ERP by cost, control, security, access, customization, maintenance, scalability, and fit for growing businesses. |
+| Excerpt | On-premise ERP gives more infrastructure control, while cloud ERP reduces infrastructure burden and improves accessibility. This guide compares the tradeoffs for growing companies. |
+| Category recommendation | `erp-business-systems` |
+
+## Internal Links To Include
+
+| Link | Status | Placement |
+|---|---|---|
+| `/services/erp-software/` | Existing service page | "How KP Infotech helps" and ERP selection sections |
+| `/services/cloud-devops/` | Existing service page | Cloud operations and infrastructure sections |
+| `/insights/odoo-erp-complete-guide/` | Existing insight page | Odoo-related ERP reading |
+| `/insights/cloud-deployment-models-diagram/` | Existing insight page | Cloud deployment model explanation |
+| `/insights/how-to-choose-erp-system/` | Future after publish | Related reading after both P0 drafts are live |
+
+## FAQ Questions
+
+- What is the difference between on-premise ERP and cloud ERP?
+- Is cloud ERP more secure than on-premise ERP?
+- Which ERP deployment model costs less?
+- Can Odoo be deployed in the cloud or on-premise?
+- When should a business choose on-premise ERP?
+- When should a business choose cloud ERP?
+
+## Redirect-Evolution Note
+
+Yes, the legacy URL should eventually change from the current service redirect to this recreated insight article after review, publishing, indexing, and verification.
+
+- Current redirect: `/on-premise-vs-cloud-erp/` -> `/services/erp-software/`
+- Future direct redirect: `/on-premise-vs-cloud-erp/` -> `/insights/on-premise-vs-cloud-erp/`
+- Warning: update the original Worker redirect source directly. Do not create a `/on-premise-vs-cloud-erp/` -> `/services/erp-software/` -> `/insights/on-premise-vs-cloud-erp/` chain.
+
+## Full Article Draft
+
+## On-premise vs cloud ERP: what is the difference?
+
+On-premise ERP is hosted on infrastructure controlled by the business, often in its own server environment or private data center. Cloud ERP is hosted on cloud infrastructure and accessed through the internet, with infrastructure operations handled by a cloud provider, hosting partner, or managed DevOps team.
+
+The difference is not only where the software runs. It affects cost, security ownership, access, maintenance, backups, scaling, updates, and internal IT workload.
+
+## Quick comparison
+
+| Factor | On-premise ERP | Cloud ERP |
+|---|---|---|
+| Infrastructure control | Higher control over servers and network | Less direct server control, more provider-managed infrastructure |
+| Upfront cost | Often higher due to hardware and setup | Often lower upfront infrastructure cost |
+| Ongoing maintenance | Business or IT partner manages servers, backups, patches | Cloud operations can be managed through provider and DevOps processes |
+| Remote access | Requires VPN or secure remote access setup | Usually easier for distributed teams |
+| Scalability | Hardware planning is needed | Capacity can usually scale more flexibly |
+| Security ownership | Business owns more infrastructure responsibility | Shared responsibility between business, cloud provider, and implementation partner |
+| Customization | Can support deep customization | Can also support customization, depending on architecture and hosting model |
+| Disaster recovery | Must be designed and tested by the business or partner | Can use cloud backup, replication, and recovery patterns |
+
+## When on-premise ERP may fit
+
+On-premise ERP can make sense when a company has strict infrastructure control requirements, reliable internal IT capacity, specific compliance needs, limited internet dependency, or legacy systems that must remain inside a controlled network.
+
+It may also fit when operations are concentrated in one location and the business already has the skills and processes to manage servers, backups, access control, monitoring, and recovery.
+
+The tradeoff is responsibility. The business must ensure infrastructure stays secure, patched, backed up, monitored, and recoverable.
+
+## When cloud ERP may fit
+
+Cloud ERP often fits growing companies that need easier access across teams, locations, warehouses, branches, or remote users. It can reduce the burden of server management and support faster scaling, backups, monitoring, and deployment workflows when set up correctly.
+
+Cloud ERP is also useful when ERP needs to connect with ecommerce, CRM, dashboards, mobile apps, AI tools, APIs, or other cloud services.
+
+The tradeoff is governance. The business must still manage access control, data permissions, backup policies, vendor risk, integration security, and operational ownership.
+
+## Cost comparison
+
+On-premise ERP cost often includes hardware, server setup, networking, security tools, backup systems, IT staff or partner support, and periodic upgrades.
+
+Cloud ERP cost often includes hosting, storage, bandwidth, managed services, monitoring, backups, security configuration, subscription fees, and DevOps support.
+
+The right comparison is total cost of ownership, not only monthly fees or server purchase cost. Include implementation, customization, integrations, migration, training, support, and long-term maintenance in both models.
+
+## Security comparison
+
+Cloud ERP is not automatically secure, and on-premise ERP is not automatically safer. Security depends on architecture and operations.
+
+Review:
+
+- User roles and access control
+- Password and multi-factor authentication policies
+- Network and API exposure
+- Backup and recovery testing
+- Patch management
+- Audit logs
+- Vendor and administrator access
+- Data residency and compliance needs
+- Monitoring and incident response
+
+Security is a shared operating discipline. Deployment model matters, but execution matters more.
+
+## Decision framework
+
+Choose on-premise ERP when infrastructure control, local hosting, or internal network dependency is a hard requirement and the company can operate the environment responsibly.
+
+Choose cloud ERP when the business needs easier access, flexible scaling, managed infrastructure patterns, cloud integrations, and less internal server workload.
+
+Choose a hybrid approach when some systems must remain controlled locally while ERP, reporting, integrations, or portals use cloud infrastructure.
+
+For more context on cloud options, see the [cloud deployment models guide](/insights/cloud-deployment-models-diagram/).
+
+## How KP Infotech helps
+
+KP Infotech supports [Odoo ERP implementation and customization](/services/erp-software/) along with [cloud and DevOps services](/services/cloud-devops/) for ERP environments that need reliable hosting, integrations, backups, monitoring, and deployment practices.
+
+The team can help evaluate ERP deployment fit, configure Odoo workflows, connect business systems, set up cloud infrastructure, build dashboards, and support ongoing operations after launch.
+
+For Odoo-specific planning, see the [Odoo ERP guide](/insights/odoo-erp-complete-guide/).
+
+## FAQs
+
+### What is the difference between on-premise ERP and cloud ERP?
+
+On-premise ERP runs on infrastructure controlled by the business. Cloud ERP runs on cloud infrastructure and is accessed over the internet, with infrastructure operations handled through cloud and DevOps processes.
+
+### Is cloud ERP more secure than on-premise ERP?
+
+Cloud ERP can be secure when access, backups, monitoring, network rules, and data controls are configured well. On-premise ERP can also be secure, but the business carries more direct responsibility for infrastructure operations.
+
+### Which ERP deployment model costs less?
+
+It depends on total cost of ownership. Compare software, implementation, hosting, hardware, support, security, backups, upgrades, integrations, and internal IT workload.
+
+### Can Odoo be deployed in the cloud or on-premise?
+
+Odoo can be deployed in different ways depending on edition, hosting model, customization needs, and support requirements. The right setup depends on operations, data, access, and maintenance needs.
+
+### When should a business choose on-premise ERP?
+
+Choose on-premise when local infrastructure control, internal hosting, or specific compliance and network requirements are more important than cloud flexibility.
+
+### When should a business choose cloud ERP?
+
+Choose cloud ERP when teams need easier remote access, flexible scaling, managed infrastructure patterns, cloud integrations, reliable backup options, and less internal server maintenance.

--- a/docs/seo-migration/p0-content-drafts/what-is-custom-software.md
+++ b/docs/seo-migration/p0-content-drafts/what-is-custom-software.md
@@ -1,0 +1,157 @@
+# What Is Custom Software? Definition, Examples, and When to Build
+
+## Draft Metadata
+
+| Field | Value |
+|---|---|
+| Proposed Sanity title | What Is Custom Software? Definition, Examples, and When to Build |
+| Proposed slug | `/insights/what-is-custom-software/` |
+| Legacy URL | `/what-is-customised-software/` |
+| Current redirect target | `/services/custom-software-development/` |
+| Recommended future redirect target | `/insights/what-is-custom-software/` |
+| Target service pillar | Custom Software Development |
+| Primary search intent | Define custom software and help a growing business decide when custom software is more appropriate than off-the-shelf tools. |
+| Target audience | Operations leaders, founders, department heads, and IT owners evaluating internal tools, portals, dashboards, integrations, or workflow systems. |
+| seoTitle | What Is Custom Software? Definition, Examples & Fit |
+| seoDescription | Learn what custom software is, when it fits growing businesses, and how it compares with off-the-shelf tools for workflows, dashboards, and integrations. |
+| Excerpt | Custom software is built around the way a business actually operates. This guide explains when it makes sense, where packaged tools fit, and how to evaluate the decision. |
+| Category recommendation | `custom-software-development` |
+
+## Internal Links To Include
+
+| Link | Status | Placement |
+|---|---|---|
+| `/services/custom-software-development/` | Existing service page | "How KP Infotech helps" and build-vs-buy sections |
+| `/services/business-automation/` | Existing service page | Automation examples section |
+| `/insights/business-process-automation-tools/` | Future after publish | Related reading after both P0 drafts are live |
+| `/insights/software-development-process-phases/` | Future after publish | Optional P1 related reading after recreation |
+
+## FAQ Questions
+
+- What is custom software in simple terms?
+- What is an example of custom software?
+- Is custom software better than off-the-shelf software?
+- When should a business build custom software?
+- How long does custom software take to build?
+- How does KP Infotech approach custom software projects?
+
+## Redirect-Evolution Note
+
+Yes, the legacy URL should eventually change from the current service redirect to this recreated insight article after the article is reviewed, published, indexed, and verified.
+
+- Current redirect: `/what-is-customised-software/` -> `/services/custom-software-development/`
+- Future direct redirect: `/what-is-customised-software/` -> `/insights/what-is-custom-software/`
+- Warning: update the original Worker redirect source directly. Do not create a `/what-is-customised-software/` -> `/services/custom-software-development/` -> `/insights/what-is-custom-software/` chain.
+
+## Full Article Draft
+
+## What is custom software?
+
+Custom software is software designed and built for a specific business process, team, customer journey, or operating model. Instead of forcing the business to work around a generic tool, custom software adapts to the company's workflows, data, roles, approvals, reports, and integrations.
+
+For a growing B2B team, custom software often becomes useful when spreadsheets, email approvals, disconnected SaaS tools, and manual reporting start slowing down daily operations. It can take the form of an internal operations portal, ERP extension, customer dashboard, vendor system, mobile app, reporting platform, or workflow automation layer.
+
+## Custom software vs off-the-shelf software
+
+Off-the-shelf software is ready-made. Custom software is designed for a specific operating need. The right choice depends on how standard or unique the workflow is.
+
+| Decision factor | Off-the-shelf software | Custom software |
+|---|---|---|
+| Speed to start | Usually faster | Requires discovery, design, and build time |
+| Workflow fit | Works best for standard processes | Fits process, roles, approvals, and exceptions |
+| Cost pattern | Subscription or license fees | Project and maintenance investment |
+| Integrations | Limited to supported connectors | Can connect ERP, CRM, spreadsheets, APIs, and databases |
+| Differentiation | Same capabilities competitors can buy | Can support business-specific ways of operating |
+| Ownership | Vendor controls roadmap | Business has more control over roadmap and data flow |
+
+Packaged software is often the right first step for accounting, payroll, CRM, messaging, or commodity use cases. Custom software becomes more relevant when a process is specific, cross-functional, or tied to operational advantage.
+
+## Common examples of custom software
+
+Custom software does not have to mean a large enterprise platform. It can start with a focused operational system that removes a repeated bottleneck.
+
+Examples include:
+
+- Internal tools for approvals, production tracking, service requests, or field operations
+- Dashboards that combine data from ERP, CRM, ecommerce, spreadsheets, and databases
+- Customer or vendor portals for orders, documents, support requests, and status visibility
+- ERP and Odoo customizations for workflows that standard modules do not cover cleanly
+- Business automation systems that route tasks, send notifications, and reduce manual follow-up
+- AI agents for document intake, internal knowledge search, support triage, or reporting assistance
+- Cloud-hosted systems with CI/CD, monitoring, access control, and backup processes
+
+The best custom software projects usually start with a specific operational problem, not with a broad desire to "build an app."
+
+## When should a business build custom software?
+
+Consider custom software when the current workflow creates repeated cost, delay, or visibility problems.
+
+Use this checklist:
+
+- The team relies on multiple spreadsheets to run a core process.
+- Data is re-entered between tools, causing errors or delays.
+- Approvals depend on email threads, chat messages, or manual reminders.
+- Leaders cannot see live operational status without asking someone to prepare a report.
+- Existing tools almost fit, but the missing parts are central to how the business works.
+- The process spans sales, operations, finance, inventory, support, or field teams.
+- A customer, vendor, or employee portal would reduce repeated status calls.
+- The workflow needs ERP, CRM, accounting, inventory, document, or third-party API integrations.
+
+If most of these are true, the question is not only "Should we build software?" It is also "What is the smallest useful system we can build first?"
+
+## When should a business avoid custom software?
+
+Custom software is not always the right answer. Avoid building when:
+
+- A reliable packaged tool solves the workflow well enough.
+- The business process is still changing every week and has not stabilized.
+- The team has no owner for requirements, adoption, and process decisions.
+- The expected benefit is unclear or impossible to prioritize.
+- The project is mostly about copying a competitor rather than fixing a real workflow.
+
+In these cases, a better first step may be process mapping, off-the-shelf tool configuration, Odoo setup, workflow automation, or a small prototype.
+
+## A practical decision framework
+
+Use four questions before approving a custom software project:
+
+1. What manual work will disappear?
+2. What business visibility will improve?
+3. Which systems must connect?
+4. Who will use the system every week?
+
+If the answers are specific, the project is easier to scope. For example, "reduce manual purchase approval follow-up" is clearer than "improve operations." "Show live inventory, pending purchases, and production status in one dashboard" is clearer than "build a reporting system."
+
+## How KP Infotech helps
+
+KP Infotech builds [custom software for growing businesses](/services/custom-software-development/) that need practical systems around real operations. That can include internal tools, dashboards, portals, workflow platforms, ERP and Odoo extensions, integrations, and cloud-hosted applications.
+
+The work usually starts with the business process: where data enters, who approves what, where delays happen, which tools already exist, and what decision-makers need to see. From there, KP Infotech can define a focused build plan, design the user workflow, connect systems, and support the application after launch.
+
+For teams that mainly need process routing, approvals, notifications, and integrations, [business automation](/services/business-automation/) may be the right starting point before a larger custom platform.
+
+## FAQs
+
+### What is custom software in simple terms?
+
+Custom software is software built for the specific needs of one business or team. It is designed around that company's workflows, data, users, and integrations instead of using a generic tool exactly as it comes.
+
+### What is an example of custom software?
+
+An example is an internal operations dashboard that pulls data from ERP, sales, inventory, and spreadsheets so managers can see orders, approvals, stock status, and delays in one place.
+
+### Is custom software better than off-the-shelf software?
+
+Not always. Off-the-shelf software is usually better for standard needs that many businesses share. Custom software is better when the workflow is specific, the integrations are important, or the process creates operational advantage.
+
+### When should a business build custom software?
+
+A business should consider custom software when manual work, disconnected tools, spreadsheet dependency, reporting delays, or process exceptions are creating measurable friction in a core workflow.
+
+### How long does custom software take to build?
+
+Timing depends on scope, integrations, approval flows, and data complexity. A focused internal tool can be planned differently from a full ERP-connected platform. The safest approach is to define a minimum useful first release before expanding.
+
+### How does KP Infotech approach custom software projects?
+
+KP Infotech starts with the operating problem, maps the workflow, defines the smallest useful system, and then builds software that can connect with tools such as ERP, CRM, spreadsheets, dashboards, and cloud infrastructure.


### PR DESCRIPTION
## Summary

- Adds a docs-only P0 content draft package under `docs/seo-migration/p0-content-drafts/`.
- Includes six reviewable `/insights/` article drafts plus a review README.
- Each draft includes proposed Sanity metadata, internal-link planning, FAQ candidates, full article copy, and redirect-evolution notes.

## Scope

- No production behavior changes.
- No Sanity writes.
- Drafts are not published yet.
- No redirect, sitemap, schema, canonical, robots/noindex, route behavior, existing metadata, or page-copy changes.

## Content QA

Reviewed each draft for:

- Alignment with KP Infotech's B2B operations technology positioning.
- No generic agency positioning.
- No fabricated client results, awards, reviews, certifications, or metrics.
- Direct-answer introductions suitable for SEO/GEO/AEO extraction.
- Comparison, checklist, or decision-framework sections where relevant.
- Six practical FAQs per draft.
- Natural internal links to relevant existing service pillars.
- Non-existent insight links marked as `future after publish`.
- Redirect-evolution notes with explicit warnings to avoid source -> service -> insight redirect chains.

No content QA blockers found.

## Verification

- `git status --short`: clean.
- Diff against `origin/main` contains only `docs/seo-migration/p0-content-drafts/`.
- Structured docs checklist: PASS for all six drafts.
- SEO title lengths: 46-58 characters.
- SEO description lengths: 145-153 characters.
- `git diff --check`: PASS.
- Docs/Markdown lint: not run because no docs or Markdown lint script is available in `package.json`.
- Build skipped because this is Markdown-only and no production behavior changed.

## Next Step

After review approval, handle article creation through a separate Sanity import workflow. Do not publish or redirect these URLs as part of this PR.