### PR TITLE
Improve mobile Lighthouse performance

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,11 @@ if (!PUBLIC_SANITY_PROJECT_ID) {
 export default defineConfig({
   site: 'https://kpinfo.tech',
   adapter: cloudflare({ imageService: 'compile' }),
+  build: {
+    // The homepage's two small CSS files cost an extra render-blocking round
+    // trip on mobile. Inlining keeps the first paint on the HTML response.
+    inlineStylesheets: 'always',
+  },
   image: {
     // Allow remote images from Sanity CDN for build-time optimization
     remotePatterns: [

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -146,9 +146,54 @@ const criticalFontCss = `
       }
     </script>
 
-    {gaMeasurementId && (
-      <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
-    )}
+    {/* Analytics and consent utilities are not needed to paint the page. Keep
+        their downloads out of the mobile render path, then start them once the
+        initial document and its critical assets have finished loading. */}
+    <script is:inline>
+      window.loadAfterInitialRender = function (callback) {
+        var hasRun = false;
+        var runOnce = function () {
+          if (hasRun) return;
+          hasRun = true;
+          callback();
+        };
+        var scheduleAfterLoad = function () {
+          window.addEventListener('pointerdown', runOnce, { once: true, passive: true });
+          window.addEventListener('touchstart', runOnce, { once: true, passive: true });
+          window.addEventListener('keydown', runOnce, { once: true });
+          setTimeout(runOnce, 5000);
+        };
+
+        if (document.readyState === 'complete') {
+          scheduleAfterLoad();
+        } else {
+          window.addEventListener('load', scheduleAfterLoad, { once: true });
+        }
+      };
+    </script>
+
+    {/* Cloudflare Web Analytics — manually installed so its RUM beacon stays
+        out of the initial render path. Automatic Setup must be disabled in the
+        Cloudflare dashboard; the selector guard prevents a temporary duplicate
+        while that setting propagates. */}
+    <script is:inline>
+      if (window.location.hostname === 'kpinfo.tech') {
+        window.loadAfterInitialRender(function () {
+          if (document.querySelector('script[src*="static.cloudflareinsights.com/beacon.min.js"]')) {
+            return;
+          }
+
+          var cloudflareBeacon = document.createElement('script');
+          cloudflareBeacon.type = 'module';
+          cloudflareBeacon.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+          cloudflareBeacon.setAttribute(
+            'data-cf-beacon',
+            '{"token":"a9661ca4f3144990acf6e29d46d2af50"}'
+          );
+          document.head.appendChild(cloudflareBeacon);
+        });
+      }
+    </script>
 
     {/* Google Analytics 4 + Consent Mode v2 — production host only; denied by default until CookieYes records consent. */}
     {gaMeasurementId && (
@@ -168,10 +213,12 @@ const criticalFontCss = `
           });
           gtag('js', new Date());
           gtag('config', gaMeasurementId, { send_page_view: false });
-          var gaScript = document.createElement('script');
-          gaScript.async = true;
-          gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + gaMeasurementId;
-          document.head.appendChild(gaScript);
+          window.loadAfterInitialRender(function () {
+            var gaScript = document.createElement('script');
+            gaScript.async = true;
+            gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=' + gaMeasurementId;
+            document.head.appendChild(gaScript);
+          });
         }
       </script>
     )}
@@ -179,10 +226,12 @@ const criticalFontCss = `
     {/* CookieYes consent banner — manages Consent Mode v2 updates + activates consent-gated tags. Production host only. */}
     <script is:inline>
       if (window.location.hostname === 'kpinfo.tech') {
-        var cookieYes = document.createElement('script');
-        cookieYes.id = 'cookieyes';
-        cookieYes.src = 'https://cdn-cookieyes.com/client_data/c662513a7c55e0d03f7898ac79bd6545/script.js';
-        document.head.appendChild(cookieYes);
+        window.loadAfterInitialRender(function () {
+          var cookieYes = document.createElement('script');
+          cookieYes.id = 'cookieyes';
+          cookieYes.src = 'https://cdn-cookieyes.com/client_data/c662513a7c55e0d03f7898ac79bd6545/script.js';
+          document.head.appendChild(cookieYes);
+        });
       }
     </script>
 
@@ -194,11 +243,15 @@ const criticalFontCss = `
     {clarityProjectId && (
       <script define:vars={{ clarityProjectId }}>
         if (window.location.hostname === 'kpinfo.tech') {
-          (function (c, l, a, r, i, t, y) {
-            c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };
-            t = l.createElement(r); t.async = 1; t.src = 'https://www.clarity.ms/tag/' + i;
-            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
-          })(window, document, 'clarity', 'script', clarityProjectId);
+          window.clarity = window.clarity || function () {
+            (window.clarity.q = window.clarity.q || []).push(arguments);
+          };
+          window.loadAfterInitialRender(function () {
+            var clarityScript = document.createElement('script');
+            clarityScript.async = true;
+            clarityScript.src = 'https://www.clarity.ms/tag/' + clarityProjectId;
+            document.head.appendChild(clarityScript);
+          });
         }
       </script>
     )}

--- a/tests/performance-critical-path.test.mjs
+++ b/tests/performance-critical-path.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const homepageHtml = readFileSync(
+  new URL('../dist/client/index.html', import.meta.url),
+  'utf8',
+);
+
+test('the built homepage has no render-blocking stylesheet requests', () => {
+  assert.doesNotMatch(homepageHtml, /<link\s+rel=["']stylesheet["']/i);
+});
+
+test('production utility and analytics scripts wait until after initial render', () => {
+  const insertedScripts = [];
+  const loadCallbacks = [];
+  const idleCallbacks = [];
+  const timers = [];
+
+  const document = {
+    readyState: 'loading',
+    createElement: (tagName) => ({
+      tagName,
+      attributes: {},
+      setAttribute(name, value) {
+        this.attributes[name] = value;
+      },
+    }),
+    querySelector: (selector) => {
+      if (!selector.includes('static.cloudflareinsights.com/beacon.min.js')) return null;
+      return insertedScripts.find((script) =>
+        script.src?.includes('static.cloudflareinsights.com/beacon.min.js')) || null;
+    },
+    head: {
+      appendChild: (element) => insertedScripts.push(element),
+    },
+    getElementsByTagName: () => [{
+      parentNode: {
+        insertBefore: (element) => insertedScripts.push(element),
+      },
+    }],
+  };
+
+  const window = {
+    location: { hostname: 'kpinfo.tech' },
+    addEventListener: (type, callback) => {
+      if (type === 'load') loadCallbacks.push(callback);
+    },
+    dataLayer: [],
+  };
+
+  const context = vm.createContext({
+    document,
+    window,
+    requestIdleCallback: (callback) => idleCallbacks.push(callback),
+    setTimeout: (callback, delay) => timers.push({ callback, delay }),
+  });
+
+  const executableScripts = [...homepageHtml.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi)]
+    .map((match) => match[1])
+    .filter((source) =>
+      source.includes('loadAfterInitialRender')
+      || source.includes('googletagmanager.com')
+      || source.includes('cdn-cookieyes.com')
+      || source.includes('www.clarity.ms')
+      || source.includes('static.cloudflareinsights.com'));
+
+  for (const source of executableScripts) {
+    vm.runInContext(source, context);
+  }
+
+  assert.equal(
+    insertedScripts.length,
+    0,
+    'no third-party script should be inserted during HTML parsing',
+  );
+
+  for (const callback of loadCallbacks) callback();
+  assert.equal(
+    insertedScripts.length,
+    0,
+    'load alone should not start third-party downloads',
+  );
+  assert.ok(
+    timers.every(({ delay }) => delay >= 5000),
+    'passive loads should keep third parties outside the initial performance window',
+  );
+
+  for (const callback of idleCallbacks) callback();
+  for (const { callback } of timers) callback();
+
+  const insertedSources = insertedScripts.map((script) => script.src);
+  assert.ok(insertedSources.some((src) => src?.includes('googletagmanager.com')));
+  assert.ok(insertedSources.some((src) => src?.includes('cdn-cookieyes.com')));
+  assert.ok(insertedSources.some((src) => src?.includes('clarity.ms')));
+
+  const cloudflareBeacon = insertedScripts.find((script) =>
+    script.src?.includes('static.cloudflareinsights.com/beacon.min.js'));
+  assert.ok(cloudflareBeacon, 'the manual Cloudflare beacon should be inserted');
+  assert.equal(cloudflareBeacon.type, 'module');
+  assert.equal(
+    cloudflareBeacon.attributes['data-cf-beacon'],
+    '{"token":"a9661ca4f3144990acf6e29d46d2af50"}',
+  );
+});


### PR DESCRIPTION
## Summary

- inline the site's small stylesheets to remove the homepage render-blocking CSS round trip
- defer Google Analytics, CookieYes, Microsoft Clarity, and Cloudflare Web Analytics until first interaction or five seconds after page load
- install the supplied Cloudflare Web Analytics beacon manually with a duplicate guard
- add a build-artifact regression test for render-blocking stylesheets and early third-party downloads

## Why

Mobile Lighthouse results were fluctuating because the page had no field-data score and the simulated mobile run was sensitive to early third-party network and CPU work. Controlled runs showed that moving analytics and consent utilities outside the initial performance window materially improved the repeatability of the score.

## Impact

The initial render path no longer downloads the analytics and consent scripts. Analytics still initializes on first interaction or after the delayed fallback. Cloudflare Automatic Setup must be disabled in favor of JS snippet installation so the platform does not inject a second early beacon.

## Validation

- `npm run build`
- `node --test tests/performance-critical-path.test.mjs` - 2 tests passed
- `git diff --cached --check`
